### PR TITLE
m6522.h (VIA) updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,36 @@ For schematics, manuals and research material, see: https://github.com/floooh/em
 
 ## What's New
 
+* **03-Jan-2020**: Another VIA- and VIC-20 related update:
+    - The VIA (m6522.h) API has been simplified: the separate m6522_iorq()
+      function to read and write chip registers has been merged into
+      the m6522_tick() function, and all IO callbacks have been removed.
+      Instead of handling the VIA IO ports through callbacks, the port input 
+      pins are now set before calling m6522_tick(),
+      and the port outputs are inspected in the pin mask returned by
+      m6522_tick(). Similar, if chip registers should be read or written,
+      the chip-select and RW pin must be set on the input pin mask
+      for m6522_tick(). This 'API streamlining' makes writing system
+      tick functions more straightforward. System schematics now translate
+      more directly into code which sets and inspects pin
+      bit masks, instead of handling the address decoding, register
+      reads/write, and IO through completely different code (such as
+      IO callbacks).
+    - The same API change (merging the iorq function into the tick function
+      has been implemented for the VIC emulation (m6561.h). In the future
+      the other chip emulations will follow too. See the ```_vic20_tick()```
+      function in the ```systems/vic20.h``` header for a code example of how
+      the new VIA and VIC APIs are used in a system's tick function.
+    - The VIA emulation is now more feature complete and accurate, but
+      not yet complete:
+        - the entire shift-register functionality is not implemented
+        - timers and interrupts are not cycle accurate in some situations
+    - The VIC-20 emulation is now good enough to support TAP-file loading
+      through c1530.h datassette emulation (this depends mostly on somewhat
+      accurate VIA timers and interrupts). Also, the first modern demo-scene
+      demos are now running in the VIC-20 emulation, although with glitches
+      here and there.
+
 * **24-Dec-2019**: A small "inbetween merge" because the feature branch I
     was working on became too unfocused: The plan was to add 1541 floppy
     support to the C64 emulation, but I soon realized that the VIA emulation

--- a/chips/m6502.h
+++ b/chips/m6502.h
@@ -339,6 +339,8 @@ uint16_t m6502_pc(m6502_t* cpu);
 #define M6502_GET_DATA(p) ((uint8_t)((p&0xFF0000ULL)>>16))
 /* merge 8-bit data bus value into 64-bit pins */
 #define M6502_SET_DATA(p,d) {p=(((p)&~0xFF0000ULL)|(((d)<<16)&0xFF0000ULL));}
+/* copy data bus value from other pin mask */
+#define M6502_COPY_DATA(p0,p1) (((p0)&~0xFF0000ULL)|((p1)&0xFF0000ULL))
 /* return a pin mask with control-pins, address and data bus */
 #define M6502_MAKE_PINS(ctrl, addr, data) ((ctrl)|(((data)<<16)&0xFF0000ULL)|((addr)&0xFFFFULL))
 /* set the port bits on the 64-bit pin mask */

--- a/chips/m6522.h
+++ b/chips/m6522.h
@@ -210,7 +210,7 @@ typedef struct {
     uint8_t inpr;
     uint8_t outr;
     uint8_t ddr;
-    uint8_t port;
+    uint8_t pins;
 } m6522_port_t;
 
 /* timer state */
@@ -287,7 +287,7 @@ static void _m6522_init_port(m6522_port_t* p) {
     p->inpr = 0xFF;
     p->outr = 0;
     p->ddr = 0;
-    p->port = 0;
+    p->pins = 0;
 }
 
 static void _m6522_init_timer(m6522_timer_t* t) {
@@ -399,9 +399,9 @@ static inline uint8_t _m6522_merge_pb7(m6522_t* c, uint8_t data) {
 }
 
 static inline uint64_t _m6522_write_port_pins(m6522_t* c, uint64_t pins) {
-    c->pa.port = (c->pa.inpr & ~c->pa.ddr) | (c->pa.outr & c->pa.ddr);
-    c->pb.port = _m6522_merge_pb7(c, (c->pb.inpr & ~c->pb.ddr) | (c->pb.outr & c->pb.ddr));
-    M6522_SET_PAB(pins, c->pa.port, c->pb.port);
+    c->pa.pins = (c->pa.inpr & ~c->pa.ddr) | (c->pa.outr & c->pa.ddr);
+    c->pb.pins = _m6522_merge_pb7(c, (c->pb.inpr & ~c->pb.ddr) | (c->pb.outr & c->pb.ddr));
+    M6522_SET_PAB(pins, c->pa.pins, c->pb.pins);
     return pins;
 }
 
@@ -582,7 +582,7 @@ static uint8_t _m6522_read(m6522_t* c, uint8_t addr) {
                 data = c->pb.inpr;
             }
             else {
-                data = c->pb.port;
+                data = c->pb.pins;
             }
             _m6522_clear_pb_intr(c);
             break;
@@ -592,7 +592,7 @@ static uint8_t _m6522_read(m6522_t* c, uint8_t addr) {
                 data = c->pa.inpr;
             }
             else {
-                data = c->pa.port;
+                data = c->pa.pins;
             }
             _m6522_clear_pa_intr(c);
             /* FIXME: handshake */
@@ -658,7 +658,7 @@ static uint8_t _m6522_read(m6522_t* c, uint8_t addr) {
                 data = c->pa.inpr;
             }
             else {
-                data = c->pa.port;
+                data = c->pa.pins;
             }
             break;
     }

--- a/chips/m6522.h
+++ b/chips/m6522.h
@@ -124,10 +124,6 @@ extern "C" {
 #define M6522_PB7       (1ULL<<63)
 #define M6522_PB_PINS   (M6522_PB0|M6522_PB1|M6522_PB2|M6522_PB3|M6522_PB4|M6522_PB5|M6522_PB6|M6522_PB7)
 
-/* pin-group-masks for m6522_tick() and m6522_iorq() */
-#define M6522_TICK_PIN_MASK     (M6522_IRQ|M6522_PA_PINS|M6522_PB_PINS|M6522_CA_PINS|M6522_CB_PINS)
-#define M6522_IORQ_PIN_MASK     (M6522_RS_PINS|M6522_DB_PINS|M6522_RW|M6522_CS1|M6522_CS2)
-
 /* register indices */
 #define M6522_REG_RB        (0)     /* input/output register B */
 #define M6522_REG_RA        (1)     /* input/output register A */
@@ -553,6 +549,7 @@ uint64_t _m6522_update_irq(m6522_t* c, uint64_t pins) {
     return pins;
 }
 
+#define _M6522_TICK_PIN_MASK (M6522_IRQ|M6522_PA_PINS|M6522_PB_PINS|M6522_CA_PINS|M6522_CB_PINS)
 uint64_t m6522_tick(m6522_t* c, uint64_t pins) {
     /* process input pins */
     _m6522_read_port_pins(c, pins);
@@ -570,7 +567,7 @@ uint64_t m6522_tick(m6522_t* c, uint64_t pins) {
     /* tick internal delay-pipelines forward */
     _m6522_tick_pipeline(c);
 
-    c->pins = (c->pins & ~M6522_TICK_PIN_MASK) | (pins & M6522_TICK_PIN_MASK);
+    c->pins = (c->pins & ~_M6522_TICK_PIN_MASK) | (pins & _M6522_TICK_PIN_MASK);
     return pins;
 }
 
@@ -749,6 +746,7 @@ static void _m6522_write(m6522_t* c, uint8_t addr, uint8_t data) {
     }
 }
 
+#define _M6522_IORQ_PIN_MASK (M6522_RS_PINS|M6522_DB_PINS|M6522_RW|M6522_CS1|M6522_CS2)
 uint64_t m6522_iorq(m6522_t* c, uint64_t pins) {
     if ((pins & (M6522_CS1|M6522_CS2)) == M6522_CS1) {
         uint8_t addr = pins & M6522_RS_PINS;
@@ -762,7 +760,7 @@ uint64_t m6522_iorq(m6522_t* c, uint64_t pins) {
             uint8_t data = M6522_GET_DATA(pins);
             _m6522_write(c, addr, data);
         }
-        c->pins = (c->pins & ~M6522_IORQ_PIN_MASK) | (pins & M6522_IORQ_PIN_MASK);
+        c->pins = (c->pins & ~_M6522_IORQ_PIN_MASK) | (pins & _M6522_IORQ_PIN_MASK);
     }
     return pins;
 }

--- a/chips/m6522.h
+++ b/chips/m6522.h
@@ -628,9 +628,12 @@ static void _m6522_tick_t2(m6522_t* c, uint64_t pins) {
     }
 
     /* reload timer from latch? this only happens when T2 is explicitly loaded, not on wrap-around */
+    /* NOTE: since writing the high-latch immediately reloads the timers, no delay-pipeline
+       is needed for T2
     if (_M6522_PIP_TEST(t->pip, M6522_PIP_TIMER_LOAD, 0)) {
         t->counter = t->latch;
     }
+    */
 }
 
 static void _m6522_tick_pipeline(m6522_t* c) {
@@ -846,7 +849,7 @@ static void _m6522_write(m6522_t* c, uint8_t addr, uint8_t data) {
             c->t1.latch = (data << 8) | (c->t1.latch & 0x00FF);
             _m6522_clear_intr(c, M6522_IRQ_T1);
             c->t1.t_bit = false;
-            _M6522_PIP_SET(c->t1.pip, M6522_PIP_TIMER_LOAD, 3);
+            c->t1.counter = c->t1.latch;
             break;
 
         case M6522_REG_T1LH:
@@ -862,7 +865,7 @@ static void _m6522_write(m6522_t* c, uint8_t addr, uint8_t data) {
             c->t2.latch = (data << 8) | (c->t2.latch & 0x00FF);
             _m6522_clear_intr(c, M6522_IRQ_T2);
             c->t2.t_bit = false;
-            _M6522_PIP_SET(c->t2.pip, M6522_PIP_TIMER_LOAD, 3);
+            c->t2.counter = c->t2.latch;
             break;
 
         case M6522_REG_SR:

--- a/chips/m6522.h
+++ b/chips/m6522.h
@@ -840,7 +840,6 @@ static void _m6522_write(m6522_t* c, uint8_t addr, uint8_t data) {
 }
 
 uint64_t m6522_tick(m6522_t* c, uint64_t pins) {
-    pins = _m6522_tick(c, pins);
     if ((pins & (M6522_CS1|M6522_CS2)) == M6522_CS1) {
         uint8_t addr = pins & M6522_RS_PINS;
         if (pins & M6522_RW) {
@@ -852,6 +851,7 @@ uint64_t m6522_tick(m6522_t* c, uint64_t pins) {
             _m6522_write(c, addr, data);
         }
     }
+    pins = _m6522_tick(c, pins);
     c->pins = pins;
     return pins;
 }

--- a/chips/m6522.h
+++ b/chips/m6522.h
@@ -40,11 +40,9 @@
     *           +-----------+           *
     *************************************
     
-    ## NOT EMULATED
+    ## How to use
 
-    Currently this just contains the minimal required functionality to make
-    some games on the Acorn Atom work (basically just timers, and even those
-    or likely not correct). 
+    TODO!
 
     ## zlib/libpng license
 
@@ -72,53 +70,63 @@ extern "C" {
 #endif
 
 /* register select same as lower 4 shared address bus bits */
-#define M6522_RS0   (1ULL<<0)
-#define M6522_RS1   (1ULL<<1)
-#define M6522_RS2   (1ULL<<2)
-#define M6522_RS3   (1ULL<<3)
-#define M6522_RS    (M6522_RS3|M6522_RS2|M6522_RS1|M6522_RS0)
+#define M6522_RS0       (1ULL<<0)
+#define M6522_RS1       (1ULL<<1)
+#define M6522_RS2       (1ULL<<2)
+#define M6522_RS3       (1ULL<<3)
+#define M6522_RS_PINS   (0x0FULL)
 
 /* data bus pins shared with CPU */
-#define M6522_D0    (1ULL<<16)
-#define M6522_D1    (1ULL<<17)
-#define M6522_D2    (1ULL<<18)
-#define M6522_D3    (1ULL<<19)
-#define M6522_D4    (1ULL<<20)
-#define M6522_D5    (1ULL<<21)
-#define M6522_D6    (1ULL<<22)
-#define M6522_D7    (1ULL<<23)
+#define M6522_D0        (1ULL<<16)
+#define M6522_D1        (1ULL<<17)
+#define M6522_D2        (1ULL<<18)
+#define M6522_D3        (1ULL<<19)
+#define M6522_D4        (1ULL<<20)
+#define M6522_D5        (1ULL<<21)
+#define M6522_D6        (1ULL<<22)
+#define M6522_D7        (1ULL<<23)
+#define M6522_DB_PINS   (0xFF0000ULL)
 
 /* control pins shared with CPU */
-#define M6522_RW    (1ULL<<24)      /* same as M6502_RW */
-#define M6522_IRQ   (1ULL<<26)      /* same as M6502_IRQ */
+#define M6522_RW        (1ULL<<24)      /* same as M6502_RW */
+#define M6522_IRQ       (1ULL<<26)      /* same as M6502_IRQ */
 
 /* control pins */
-#define M6522_CS1   (1ULL<<40)      /* chip-select 1, to select: CS1 high, CS2 low */
-#define M6522_CS2   (1ULL<<41)      /* chip-select 2 */
-#define M6522_CA1   (1ULL<<42)      /* peripheral A control 1 */
-#define M6522_CA2   (1ULL<<43)      /* peripheral A control 2 */
-#define M6522_CB1   (1ULL<<44)      /* peripheral B control 1 */
-#define M6522_CB2   (1ULL<<45)      /* peripheral B control 2 */
+#define M6522_CS1       (1ULL<<40)      /* chip-select 1, to select: CS1 high, CS2 low */
+#define M6522_CS2       (1ULL<<41)      /* chip-select 2 */
+
+#define M6522_CA1       (1ULL<<42)      /* peripheral A control 1 */
+#define M6522_CA2       (1ULL<<43)      /* peripheral A control 2 */
+#define M6522_CB1       (1ULL<<44)      /* peripheral B control 1 */
+#define M6522_CB2       (1ULL<<45)      /* peripheral B control 2 */
+#define M6522_CA_PINS   (M6522_CA1|M6522_CA2)
+#define M6522_CB_PINS   (M6522_CB1|M6522_CB2)
 
 /* peripheral A port */
-#define M6522_PA0   (1ULL<<48)
-#define M6522_PA1   (1ULL<<49)
-#define M6522_PA2   (1ULL<<50)
-#define M6522_PA3   (1ULL<<51)
-#define M6522_PA4   (1ULL<<52)
-#define M6522_PA5   (1ULL<<53)
-#define M6522_PA6   (1ULL<<54)
-#define M6522_PA7   (1ULL<<55)
+#define M6522_PA0       (1ULL<<48)
+#define M6522_PA1       (1ULL<<49)
+#define M6522_PA2       (1ULL<<50)
+#define M6522_PA3       (1ULL<<51)
+#define M6522_PA4       (1ULL<<52)
+#define M6522_PA5       (1ULL<<53)
+#define M6522_PA6       (1ULL<<54)
+#define M6522_PA7       (1ULL<<55)
+#define M6522_PA_PINS   (M6522_PA0|M6522_PA1|M6522_PA2|M6522_PA3|M6522_PA4|M6522_PA5|M6522_PA6|M6522_PA7)
 
 /* peripheral B port */
-#define M6522_PB0   (1ULL<<56)
-#define M6522_PB1   (1ULL<<57)
-#define M6522_PB2   (1ULL<<58)
-#define M6522_PB3   (1ULL<<59)
-#define M6522_PB4   (1ULL<<60)
-#define M6522_PB5   (1ULL<<61)
-#define M6522_PB6   (1ULL<<62)
-#define M6522_PB7   (1ULL<<63)
+#define M6522_PB0       (1ULL<<56)
+#define M6522_PB1       (1ULL<<57)
+#define M6522_PB2       (1ULL<<58)
+#define M6522_PB3       (1ULL<<59)
+#define M6522_PB4       (1ULL<<60)
+#define M6522_PB5       (1ULL<<61)
+#define M6522_PB6       (1ULL<<62)
+#define M6522_PB7       (1ULL<<63)
+#define M6522_PB_PINS   (M6522_PB0|M6522_PB1|M6522_PB2|M6522_PB3|M6522_PB4|M6522_PB5|M6522_PB6|M6522_PB7)
+
+/* pin-group-masks for m6522_tick() and m6522_iorq() */
+#define M6522_TICK_PIN_MASK     (M6522_IRQ|M6522_PA_PINS|M6522_PB_PINS|M6522_CA_PINS|M6522_CB_PINS)
+#define M6522_IORQ_PIN_MASK     (M6522_RS_PINS|M6522_DB_PINS|M6522_RW|M6522_CS1|M6522_CS2)
 
 /* register indices */
 #define M6522_REG_RB        (0)     /* input/output register B */
@@ -197,12 +205,6 @@ extern "C" {
 #define M6522_PIP_TIMER_LOAD    (8)
 #define M6522_PIP_IRQ           (0)
 
-/* port in/out callbacks */
-#define M6522_PORT_A (0)
-#define M6522_PORT_B (1)
-typedef uint8_t (*m6522_in_t)(int port_id, void* user_data);
-typedef void (*m6522_out_t)(int port_id, uint8_t data, void* user_data);
-
 /* I/O port state */
 typedef struct {
     uint8_t inpr;
@@ -231,13 +233,6 @@ typedef struct {
     uint16_t pip;
 } m6522_int_t;
 
-/* m6522 initialization parameters */
-typedef struct {
-    m6522_in_t in_cb;
-    m6522_out_t out_cb;
-    void* user_data;
-} m6522_desc_t;
-
 /* m6522 state */
 typedef struct {
     m6522_port_t pa;
@@ -247,11 +242,7 @@ typedef struct {
     m6522_int_t intr;
     uint8_t acr;        /* auxilary control register */
     uint8_t pcr;        /* peripheral control register */
-    uint64_t tick_pins; /* pin state after last m6522_tick() */
-    uint64_t iorq_pins; /* pin state after last m6522_iorq() */
-    m6522_in_t in_cb;
-    m6522_out_t out_cb;
-    void* user_data;
+    uint64_t pins;
 } m6522_t;
 
 /* extract 8-bit data bus from 64-bit pins */
@@ -260,6 +251,10 @@ typedef struct {
 #define M6522_SET_DATA(p,d) {p=((p&~0xFF0000)|(((d)&0xFF)<<16));}
 /* merge 4-bit address into 64-bit pins */
 #define M6522_SET_ADDR(p,d) {p=((p&~0xF)|((d)&0xF));}
+/* extract port A pins */
+#define M6522_GET_PA(p) ((uint8_t)(p>>48))
+/* extract port B pins */
+#define M6522_GET_PB(p) ((uint8_t)(p>>56))
 /* merge port A pins into pin mask */
 #define M6522_SET_PA(p,a) {p=(p&0xFF00FFFFFFFFFFFFULL)|(((a)&0xFFULL)<<48);}
 /* merge port B pins into pin mask */
@@ -268,7 +263,7 @@ typedef struct {
 #define M6522_SET_PAB(p,a,b) {p=(p&0x0000FFFFFFFFFFFFULL)|(((a)&0xFFULL)<<48)|(((b)&0xFFULL)<<56);}
 
 /* initialize a new 6522 instance */
-void m6522_init(m6522_t* m6522, const m6522_desc_t* desc);
+void m6522_init(m6522_t* m6522);
 /* reset an existing 6522 instance */
 void m6522_reset(m6522_t* m6522);
 /* perform an IO request */
@@ -309,12 +304,9 @@ static void _m6522_init_interrupt(m6522_int_t* intr) {
     intr->pip = 0;
 }
 
-void m6522_init(m6522_t* c, const m6522_desc_t* desc) {
-    CHIPS_ASSERT(c && desc && desc->in_cb && desc->out_cb);
+void m6522_init(m6522_t* c) {
+    CHIPS_ASSERT(c);
     memset(c, 0, sizeof(*c));
-    c->in_cb = desc->in_cb;
-    c->out_cb = desc->out_cb;
-    c->user_data = desc->user_data;
     _m6522_init_port(&c->pa);
     _m6522_init_port(&c->pb);
     _m6522_init_timer(&c->t1);
@@ -341,8 +333,7 @@ void m6522_reset(m6522_t* c) {
     _m6522_init_interrupt(&c->intr);
     c->acr = 0;
     c->pcr = 0;
-    c->tick_pins = 0;
-    c->iorq_pins = 0;
+    c->pins = 0;
 }
 
 /*--- delay-pipeline macros ---*/
@@ -355,6 +346,48 @@ void m6522_reset(m6522_t* c) {
 #define _M6522_PIP_TEST(pip,offset,pos) (0!=(pip&(1<<(offset+pos))))
 
 /*--- port implementation ---*/
+static inline bool _m6522_ca1_triggered(m6522_t* c, uint64_t pins) {
+    if (M6522_PCR_CA1_LOW_TO_HIGH(c)) {
+        /* check for CA1 rising edge */
+        return (M6522_CA1 & (pins & (pins ^ c->pins)));
+    }
+    else {
+        /* check for CA1 falling edge */
+        return (M6522_CA1 & (~pins & (pins ^ c->pins)));
+    }
+}
+
+static inline bool _m6522_cb1_triggered(m6522_t* c, uint64_t pins) {
+    if (M6522_PCR_CB1_LOW_TO_HIGH(c)) {
+        /* check for CA1 rising edge */
+        return (M6522_CB1 & (pins & (pins ^ c->pins)));
+    }
+    else {
+        /* check for CA1 falling edge */
+        return (M6522_CB1 & (~pins & (pins ^ c->pins)));
+    }
+}
+
+static inline void _m6522_read_port_pins(m6522_t* c, uint64_t pins) {
+    /* with latching enabled, only update input register when CA1 / CB1 goes active */
+    if (M6522_ACR_PA_LATCH_ENABLE(c)) {
+        if (_m6522_ca1_triggered(c, pins)) {
+            c->pa.inpr = M6522_GET_PA(pins);
+        }
+    }
+    else {
+        c->pa.inpr = M6522_GET_PA(pins);
+    }
+    if (M6522_ACR_PB_LATCH_ENABLE(c)) {
+        if (_m6522_cb1_triggered(c, pins)) {
+            c->pb.inpr = M6522_GET_PB(pins);
+        }
+    }
+    else {
+        c->pb.inpr = M6522_GET_PB(pins);
+    }
+}
+
 static inline uint8_t _m6522_merge_pb7(m6522_t* c, uint8_t data) {
     if (M6522_ACR_T1_SET_PB7(c)) {
         data &= ~(1<<7);
@@ -365,32 +398,11 @@ static inline uint8_t _m6522_merge_pb7(m6522_t* c, uint8_t data) {
     return data;
 }
 
-static inline void _m6522_output_pa(m6522_t* c) {
-    uint8_t data = (c->pa.outr & c->pa.ddr) | ~c->pa.ddr;
-    c->out_cb(M6522_PORT_A, data, c->user_data);
-    c->pa.port = data;
-}
-
-static inline void _m6522_output_pb(m6522_t* c) {
-    uint8_t data = (c->pb.outr & c->pb.ddr) | ~c->pb.ddr;
-    data = _m6522_merge_pb7(c, data);
-    c->out_cb(M6522_PORT_B, data, c->user_data);
-    c->pb.port = data;
-}
-
-static inline uint8_t _m6522_input_pa(m6522_t* c) {
-    c->pa.inpr = c->in_cb(M6522_PORT_A, c->user_data);
-    uint8_t data = (c->pa.inpr & ~c->pa.ddr) | (c->pa.outr & c->pa.ddr);
-    c->pa.port = data;
-    return data;
-}
-
-static inline uint8_t _m6522_input_pb(m6522_t* c) {
-    c->pb.inpr = c->in_cb(M6522_PORT_B, c->user_data);
-    uint8_t data = (c->pb.inpr & ~c->pb.ddr) | (c->pb.outr & c->pb.ddr);
-    data = _m6522_merge_pb7(c, data);
-    c->pb.port = data;
-    return data;
+static inline uint64_t _m6522_write_port_pins(m6522_t* c, uint64_t pins) {
+    c->pa.port = (c->pa.inpr & ~c->pa.ddr) | (c->pa.outr & c->pa.ddr);
+    c->pb.port = _m6522_merge_pb7(c, (c->pb.inpr & ~c->pb.ddr) | (c->pb.outr & c->pb.ddr));
+    M6522_SET_PAB(pins, c->pa.port, c->pb.port);
+    return pins;
 }
 
 static inline void _m6522_set_intr(m6522_t* c, uint8_t data) {
@@ -441,7 +453,6 @@ void _m6522_tick_t1(m6522_t* c, uint64_t pins) {
     }
 
     /* timer underflow? */
-    bool old_t_out = t->t_out;
     t->t_out = (0 == t->counter) && _M6522_PIP_TEST(t->pip, M6522_PIP_TIMER_COUNT, 1);
     if (t->t_out) {
         /* continuous or oneshot mode? */
@@ -462,9 +473,6 @@ void _m6522_tick_t1(m6522_t* c, uint64_t pins) {
             }
         }
     }
-    if (old_t_out != t->t_out) {
-        _m6522_output_pb(c);
-    }
 
     /* reload timer from latch? */
     if (_M6522_PIP_TEST(t->pip, M6522_PIP_TIMER_LOAD, 0)) {
@@ -480,7 +488,7 @@ void _m6522_tick_t2(m6522_t* c, uint64_t pins) {
     /* either decrement on PB6, or on tick */
     if (M6522_ACR_T2_COUNT_PB6(c)) {
         /* count falling edge of PB6 */
-        if (M6522_PB6 & (~pins & (pins ^ c->tick_pins))) {
+        if (M6522_PB6 & (~pins & (pins ^ c->pins))) {
             t->counter--;
         }
     }
@@ -527,29 +535,42 @@ void _m6522_tick_pipeline(m6522_t* c) {
     c->intr.pip = (c->intr.pip >> 1) & 0x7F7F;
 }
 
-void _m6522_update_irq(m6522_t* c, uint64_t pins) {
+uint64_t _m6522_update_irq(m6522_t* c, uint64_t pins) {
     /* FIXME interrupts for CA1, CA2, CB1, CB2, SR */
 
     /* main interrupt bit (delayed by pip) */
     if (_M6522_PIP_TEST(c->intr.pip, M6522_PIP_IRQ, 0)) {
         c->intr.ifr |= (1<<7);
     }
-}
 
-uint64_t m6522_tick(m6522_t* c, uint64_t pins) {
-    _m6522_tick_t1(c, pins);
-    _m6522_tick_t2(c, pins);
-    _m6522_update_irq(c, pins);
-    _m6522_tick_pipeline(c);
+    /* merge IRQ bit */
     if (0 != (c->intr.ifr & (1<<7))) {
         pins |= M6522_IRQ;
-        c->iorq_pins |= M6522_IRQ;
     }
     else {
         pins &= ~M6522_IRQ;
-        c->iorq_pins &= ~M6522_IRQ;
     }
-    c->tick_pins = pins;
+    return pins;
+}
+
+uint64_t m6522_tick(m6522_t* c, uint64_t pins) {
+    /* process input pins */
+    _m6522_read_port_pins(c, pins);
+
+    /* tick timers */
+    _m6522_tick_t1(c, pins);
+    _m6522_tick_t2(c, pins);
+
+    /* update interrupt bits */
+    pins = _m6522_update_irq(c, pins);
+
+    /* merge port output pins */
+    pins = _m6522_write_port_pins(c, pins);
+
+    /* tick internal delay-pipelines forward */
+    _m6522_tick_pipeline(c);
+
+    c->pins = (c->pins & ~M6522_TICK_PIN_MASK) | (pins & M6522_TICK_PIN_MASK);
     return pins;
 }
 
@@ -561,7 +582,7 @@ static uint8_t _m6522_read(m6522_t* c, uint8_t addr) {
                 data = c->pb.inpr;
             }
             else {
-                data = _m6522_input_pb(c);
+                data = c->pb.port;
             }
             _m6522_clear_pb_intr(c);
             break;
@@ -571,7 +592,7 @@ static uint8_t _m6522_read(m6522_t* c, uint8_t addr) {
                 data = c->pa.inpr;
             }
             else {
-                data = _m6522_input_pa(c);
+                data = c->pa.port;
             }
             _m6522_clear_pa_intr(c);
             /* FIXME: handshake */
@@ -637,7 +658,7 @@ static uint8_t _m6522_read(m6522_t* c, uint8_t addr) {
                 data = c->pa.inpr;
             }
             else {
-                data = _m6522_input_pa(c);
+                data = c->pa.port;
             }
             break;
     }
@@ -648,14 +669,12 @@ static void _m6522_write(m6522_t* c, uint8_t addr, uint8_t data) {
     switch (addr) {
         case M6522_REG_RB:
             c->pb.outr = data;
-            _m6522_output_pb(c);
             _m6522_clear_pb_intr(c);
             /* FIXME: handshake */
             break;
         
         case M6522_REG_RA:
             c->pa.outr = data;
-            _m6522_output_pa(c);
             _m6522_clear_pa_intr(c);
             /* FIXME: handshake */
             /* FIXME: pulse output */
@@ -663,12 +682,10 @@ static void _m6522_write(m6522_t* c, uint8_t addr, uint8_t data) {
         
         case M6522_REG_DDRB:
             c->pb.ddr = data;
-            _m6522_output_pb(c);
             break;
     
         case M6522_REG_DDRA:
             c->pa.ddr = data;
-            _m6522_output_pa(c);
             break;
 
         case M6522_REG_T1CL:
@@ -680,9 +697,6 @@ static void _m6522_write(m6522_t* c, uint8_t addr, uint8_t data) {
             c->t1.latch = (data << 8) | (c->t1.latch & 0x00FF);
             _m6522_clear_intr(c, M6522_IRQ_T1);
             c->t1.t_bit = false;
-            if (M6522_ACR_T1_SET_PB7(c)) {
-                _m6522_output_pb(c);
-            }
             _M6522_PIP_SET(c->t1.pip, M6522_PIP_TIMER_LOAD, 1);
             break;
 
@@ -708,7 +722,6 @@ static void _m6522_write(m6522_t* c, uint8_t addr, uint8_t data) {
 
         case M6522_REG_ACR:
             c->acr = data;
-            _m6522_output_pb(c);
             /* FIXME: shift timer */
             if (M6522_ACR_T1_CONTINUOUS(c)) {
                 /* add counter delay */
@@ -732,14 +745,13 @@ static void _m6522_write(m6522_t* c, uint8_t addr, uint8_t data) {
 
         case M6522_REG_RA_NOH:
             c->pa.outr = data;
-            _m6522_output_pa(c);
             break;
     }
 }
 
 uint64_t m6522_iorq(m6522_t* c, uint64_t pins) {
     if ((pins & (M6522_CS1|M6522_CS2)) == M6522_CS1) {
-        uint8_t addr = pins & M6522_RS;
+        uint8_t addr = pins & M6522_RS_PINS;
         if (pins & M6522_RW) {
             /* a read operation */
             uint8_t data = _m6522_read(c, addr);
@@ -750,8 +762,7 @@ uint64_t m6522_iorq(m6522_t* c, uint64_t pins) {
             uint8_t data = M6522_GET_DATA(pins);
             _m6522_write(c, addr, data);
         }
-        M6522_SET_PAB(pins, c->pa.port, c->pb.port);
-        c->iorq_pins = pins;
+        c->pins = (c->pins & ~M6522_IORQ_PIN_MASK) | (pins & M6522_IORQ_PIN_MASK);
     }
     return pins;
 }

--- a/chips/m6561.h
+++ b/chips/m6561.h
@@ -73,7 +73,7 @@ extern "C" {
 #define M6561_D7    (1ULL<<23)
 
 /* control pins shared with CPU 
-    NOTE that there is no dedicated chip-select pin, instead
+    NOTE that a real VIC has no dedicated chip-select pin, instead
     registers are read and written during the CPU's 'shared bus
     half-cycle', and the following address bus pin mask is
     active:
@@ -83,14 +83,23 @@ extern "C" {
 
     When this is true, the pins A3..A0 select the chip register.
 
-    Use the M6561_SELECTED() macro to decide whether to call
-    m6561_iorq()
+    To simplify the emulated address decoding logic, we define
+    a 'virtual' chip select pin, this must be set when a
+    memory access is in the general 'IO region', and in addition,
+    the M6561_SELECT_ADDR(pins) macro returns true:
+
+    uint64_t vic_pins = pins & M6502_PIN_MASK;
+    if (M6561_SELECTED_ADDR(pins)) {
+        vic_pins |= M6561_CS;
+    }
 */
 #define M6561_RW    (1ULL<<24)      /* same as M6502_RW */
 
-#define M6561_CS_MASK           (M6561_A13|M6561_A12|M6561_A11|M6561_A10|M6561_A9|M6561_A8)
-#define M6561_CS_VALUE          (M6561_A12)
-#define M6561_SELECTED(pins)    ((pins&M6561_CS_MASK)==M6561_CS_VALUE)
+#define M6561_CS        (1ULL<<40)      /* virtual chip-select pin */
+#define M6561_SAMPLE    (1ULL<<41)      /* virtual 'audio sample ready' pin */
+
+/* use this macro to check whether the address bus pins are in the right chip-select state */
+#define M6561_SELECTED_ADDR(pins) ((pins&(M6561_A13|M6561_A12|M6561_A11|M6561_A10|M6561_A9|M6561_A8))==M6561_A12)
 
 #define M6561_NUM_REGS (16)
 #define M6561_REG_MASK (M6561_NUM_REGS-1)
@@ -220,16 +229,12 @@ typedef struct {
 void m6561_init(m6561_t* vic, const m6561_desc_t* desc);
 /* reset a m6561_t instance */
 void m6561_reset(m6561_t* vic);
+/* tick the m6561_t instance */
+uint64_t m6561_tick(m6561_t* vic, uint64_t pins);
 /* get the visible display width in pixels */
 int m6561_display_width(m6561_t* vic);
 /* get the visible display height in pixels */
 int m6561_display_height(m6561_t* vic);
-/* read/write m6561 registers */
-uint64_t m6561_iorq(m6561_t* vic, uint64_t pins);
-/* tick the m6561_t instance to generate video output */
-void m6561_tick_video(m6561_t* vic);
-/* tick the m6561_t instance to generate audio, returns true when sample is ready */
-bool m6561_tick_audio(m6561_t* vic);
 /* get 32-bit RGBA8 value from color index (0..15) */
 uint32_t m6561_color(int i);
 
@@ -391,37 +396,6 @@ static void _m6561_regs_dirty(m6561_t* vic) {
     vic->sound.volume = vic->regs[14] & 0xF;
 }
 
-uint64_t m6561_iorq(m6561_t* vic, uint64_t pins) {
-    // FIXME: read from 'unmapped' areas returns last fetched graphics data
-    CHIPS_ASSERT(vic);
-    uint8_t addr = pins & M6561_REG_MASK;
-    if (pins & M6561_RW) {
-        /* read */
-        uint8_t data;
-        switch (addr) {
-            case 3:
-                data = ((vic->rs.v_count & 1)<<7) | (vic->regs[addr] & 0x7F);
-                break;
-            case 4:
-                data = (vic->rs.v_count>>1) & 0xFF;
-                break;
-            /* not implemented: light pen and potentiometers */
-            default:
-                data = vic->regs[addr];
-                break;
-        }
-        M6561_SET_DATA(pins, data);
-    }
-    else {
-        /* write */
-        const uint8_t data = M6561_GET_DATA(pins);
-        vic->regs[addr] = data;
-        _m6561_regs_dirty(vic);
-    }
-    vic->pins = pins;
-    return pins;
-}
-
 static inline void _m6561_decode_pixels(m6561_t* vic, uint32_t* dst) {
     if (vic->border.enabled) {
         for (int i = 0; i < 4; i++) {
@@ -467,7 +441,7 @@ static inline void _m6561_decode_pixels(m6561_t* vic, uint32_t* dst) {
 }
 
 /* tick function for video output */
-void m6561_tick_video(m6561_t* vic) {
+static void _m6561_tick_video(m6561_t* vic) {
 
     /* decode pixels, each tick is 4 pixels */
     if (vic->crt.rgba8_buffer) {
@@ -586,7 +560,7 @@ static inline float _m6561_dcadjust(m6561_sound_t* snd, float s) {
 }
 
 /* tick the audio engine, return true if a new sample if ready */
-bool m6561_tick_audio(m6561_t* vic) {
+static bool _m6561_tick_audio(m6561_t* vic) {
     m6561_sound_t* snd = &vic->sound;
     /* tick tone voices */
     for (int i = 0; i < 3; i++) {
@@ -638,4 +612,48 @@ bool m6561_tick_audio(m6561_t* vic) {
         return false;
     }
 }
+
+/* chip-selected macro (A12 must be active in A8..A13) */
+uint64_t m6561_tick(m6561_t* vic, uint64_t pins) {
+
+    /* perform register read/write */
+    if (pins & M6561_CS) {
+        // FIXME: read from 'unmapped' areas returns last fetched graphics data
+        uint8_t addr = pins & M6561_REG_MASK;
+        if (pins & M6561_RW) {
+            /* read */
+            uint8_t data;
+            switch (addr) {
+                case 3:
+                    data = ((vic->rs.v_count & 1)<<7) | (vic->regs[addr] & 0x7F);
+                    break;
+                case 4:
+                    data = (vic->rs.v_count>>1) & 0xFF;
+                    break;
+                /* not implemented: light pen and potentiometers */
+                default:
+                    data = vic->regs[addr];
+                    break;
+            }
+            M6561_SET_DATA(pins, data);
+        }
+        else {
+            /* write */
+            const uint8_t data = M6561_GET_DATA(pins);
+            vic->regs[addr] = data;
+            _m6561_regs_dirty(vic);
+        }
+    }
+
+    /* perform per-tick actions */
+    _m6561_tick_video(vic);
+    pins &= ~M6561_SAMPLE;
+    if (_m6561_tick_audio(vic)) {
+        pins |= M6561_SAMPLE;
+    }
+    vic->pins = pins;
+    return pins;
+}
+
+
 #endif

--- a/chips/m6561.h
+++ b/chips/m6561.h
@@ -392,8 +392,7 @@ static void _m6561_regs_dirty(m6561_t* vic) {
 }
 
 uint64_t m6561_iorq(m6561_t* vic, uint64_t pins) {
-    // FIXME: read from 'unmapped' areas returns last
-    // fetched graphics data
+    // FIXME: read from 'unmapped' areas returns last fetched graphics data
     CHIPS_ASSERT(vic);
     uint8_t addr = pins & M6561_REG_MASK;
     if (pins & M6561_RW) {
@@ -510,15 +509,15 @@ void m6561_tick_video(m6561_t* vic) {
     /* fetch data */
     if (vic->rs.vc & 1) {
         /* a g-access (graphics data) into pixel shifter */
-        uint16_t addr = vic->mem.g_addr_base |
-                        ((vic->mem.c_value & 0xFF) * vic->rs.row_height) |
+        uint16_t addr = vic->mem.g_addr_base +
+                        ((vic->mem.c_value & 0xFF) * vic->rs.row_height) +
                         vic->rs.rc;
         vic->gunit.shift = (uint8_t) vic->fetch_cb(addr, vic->user_data);
         vic->gunit.color = (vic->mem.c_value>>8) & 0xF;
     }
     else {
         /* a c-access (character code and color) */
-        uint16_t addr = vic->mem.c_addr_base | (vic->rs.vc>>1);
+        uint16_t addr = vic->mem.c_addr_base + (vic->rs.vc>>1);
         vic->mem.c_value = vic->fetch_cb(addr, vic->user_data);
     }
     if (!vic->rs.vc_disabled) {

--- a/codegen/m6502.template.h
+++ b/codegen/m6502.template.h
@@ -339,6 +339,8 @@ uint16_t m6502_pc(m6502_t* cpu);
 #define M6502_GET_DATA(p) ((uint8_t)((p&0xFF0000ULL)>>16))
 /* merge 8-bit data bus value into 64-bit pins */
 #define M6502_SET_DATA(p,d) {p=(((p)&~0xFF0000ULL)|(((d)<<16)&0xFF0000ULL));}
+/* copy data bus value from other pin mask */
+#define M6502_COPY_DATA(p0,p1) (((p0)&~0xFF0000ULL)|((p1)&0xFF0000ULL))
 /* return a pin mask with control-pins, address and data bus */
 #define M6502_MAKE_PINS(ctrl, addr, data) ((ctrl)|(((data)<<16)&0xFF0000ULL)|((addr)&0xFFFFULL))
 /* set the port bits on the 64-bit pin mask */

--- a/systems/atom.h
+++ b/systems/atom.h
@@ -198,8 +198,6 @@ static uint64_t _atom_tick(atom_t* sys, uint64_t pins);
 static uint64_t _atom_vdg_fetch(uint64_t pins, void* user_data);
 static uint8_t _atom_ppi_in(int port_id, void* user_data);
 static uint64_t _atom_ppi_out(int port_id, uint64_t pins, uint8_t data, void* user_data);
-static uint8_t _atom_via_in(int port_id, void* user_data);
-static void _atom_via_out(int port_id, uint8_t data, void* user_data);
 static void _atom_init_keymap(atom_t* sys);
 static void _atom_init_memorymap(atom_t* sys);
 static uint64_t _atom_osload(atom_t* sys, uint64_t pins);
@@ -248,12 +246,7 @@ void atom_init(atom_t* sys, const atom_desc_t* desc) {
     ppi_desc.user_data = sys;
     i8255_init(&sys->ppi, &ppi_desc);
 
-    m6522_desc_t via_desc;
-    _ATOM_CLEAR(via_desc);
-    via_desc.in_cb = _atom_via_in;
-    via_desc.out_cb = _atom_via_out;
-    via_desc.user_data = sys;
-    m6522_init(&sys->via, &via_desc);
+    m6522_init(&sys->via);
 
     const int audio_hz = _ATOM_DEFAULT(desc->audio_sample_rate, 44100);
     const float audio_vol = _ATOM_DEFAULT(desc->audio_volume, 0.5f);
@@ -596,15 +589,6 @@ uint8_t _atom_ppi_in(int port_id, void* user_data) {
         }
     }
     return data;
-}
-
-static void _atom_via_out(int port_id, uint8_t data, void* user_data) {
-    /* FIXME */
-}
-
-static uint8_t _atom_via_in(int port_id, void* user_data) {
-    /* FIXME */
-    return 0x00;
 }
 
 static void _atom_init_keymap(atom_t* sys) {

--- a/systems/c1530.h
+++ b/systems/c1530.h
@@ -48,15 +48,16 @@
     ~~~
 
     Use the following functions to insert and remove a tape, with a .TAP
-    file loading into memory:
+    file loading into memory, or check if a tape is inserted:
 
     ~~~C
     bool c1530_insert_tape(c1530_t* sys, const uint8_t* ptr, int num_bytes);
     void c1530_remove_tape(c1530_t* sys);
+    bool c1530_tape_inserted(c1530_t* sys);
     ~~~
 
     Call the following functions to control the tape motor (press the Play
-    or Stop buttons), and check if the motor is on.
+    or Stop buttons):
 
     ~~~C
     void c1530_play(c1530_t* sys);
@@ -113,7 +114,7 @@ typedef struct {
     bool valid;         /* true between c1530_init() and c1530_discard() */
     uint32_t size;      /* tape_size > 0: a tape is inserted */
     uint32_t pos;
-    uint32_t tick_count;
+    uint32_t pulse_count;
     uint8_t buf[C1530_MAX_TAPE_SIZE];
 } c1530_t;
 
@@ -129,6 +130,8 @@ void c1530_tick(c1530_t* sys);
 bool c1530_insert_tape(c1530_t* sys, const uint8_t* ptr, int num_bytes);
 /* remove tape file */
 void c1530_remove_tape(c1530_t* sys);
+/* return true if a tape is currently inserted */
+bool c1530_tape_inserted(c1530_t* sys);
 /* start the tape (press the Play button) */
 void c1530_play(c1530_t* sys);
 /* stop the tape (unpress the Play button */
@@ -166,7 +169,7 @@ void c1530_reset(c1530_t* sys) {
     sys->cas_port = 0;
     sys->size = 0;
     sys->pos = 0;
-    sys->tick_count = 0;
+    sys->pulse_count = 0;
 }
 
 /* C64 TAP file header */
@@ -203,7 +206,7 @@ bool c1530_insert_tape(c1530_t* sys, const uint8_t* ptr, int num_bytes) {
     memcpy(sys->buf, ptr, hdr->size);
     sys->size = hdr->size;
     sys->pos = 0;
-    sys->tick_count = 0;
+    sys->pulse_count = 0;
     return true;
 }
 
@@ -229,29 +232,34 @@ void c1530_remove_tape(c1530_t* sys) {
     c1530_stop(sys);
     sys->size = 0;
     sys->pos = 0;
-    sys->tick_count = 0;
+    sys->pulse_count = 0;
+}
+
+bool c1530_tape_inserted(c1530_t* sys) {
+    CHIPS_ASSERT(sys && sys->valid);
+    return sys->size > 0;
 }
 
 void c1530_tick(c1530_t* sys) {
     CHIPS_ASSERT(sys && sys->valid);
     *sys->cas_port &= ~C1530_CASPORT_READ;
     if (c1530_is_motor_on(sys) && (sys->size > 0) && (sys->pos <= sys->size)) {
-        if (sys->tick_count == 0) {
+        if (sys->pulse_count == 0) {
             uint8_t val = sys->buf[sys->pos++];
             if (val == 0) {
                 uint8_t s[3];
                 for (int i = 0; i < 3; i++) {
                     s[i] = sys->buf[sys->pos++];
                 }
-                sys->tick_count = (s[2]<<16) | (s[1]<<8) | s[0];
+                sys->pulse_count = (s[2]<<16) | (s[1]<<8) | s[0];
             }
             else {
-                sys->tick_count = val * 8;
+                sys->pulse_count = val * 8;
             }
             *sys->cas_port |= C1530_CASPORT_READ;
         }
         else {
-            sys->tick_count--;
+            sys->pulse_count--;
         }
     }
 }

--- a/systems/c1541.h
+++ b/systems/c1541.h
@@ -123,10 +123,8 @@ void c1541_init(c1541_t* sys, const c1541_desc_t* desc) {
     m6502_desc_t cpu_desc;
     memset(&cpu_desc, 0, sizeof(cpu_desc));
     sys->pins = m6502_init(&sys->cpu, &cpu_desc);
-    m6522_desc_t via_desc;
-    memset(&via_desc, 0, sizeof(via_desc));
-//    m6522_init(&sys->via_1, &via_desc);
-//    m6522_init(&sys->via_2, &via_desc);
+    m6522_init(&sys->via_1);
+    m6522_init(&sys->via_2);
 
     /* setup memory map */
     mem_init(&sys->mem);

--- a/systems/vic20.h
+++ b/systems/vic20.h
@@ -330,23 +330,19 @@ void vic20_init(vic20_t* sys, const vic20_desc_t* desc) {
     /*
         VIC-I memory map:
 
-        0x0000..0x0FFF  character ROM
-        0x1000..0x13FF  VIC and VIA registers
-        0x1400..0x17FF  color RAM
-        0x1800..0x1BFF  exp 1
-        0x1C00..0x1FFF  exp 2
-        0x2000..0x23FF  system RAM (CPU: 0x0000..0x0400)
-        0x2400..0x2FFF  expansion RAM
-        0x3000..0x3FFF  user RAM (CPU: 0x1000..0x1FFF)
+        The VIC-I has 14 address bus bits VA0..VA13, for 16 KB of
+        addressable memory. Bits VA0..VA12 are identical with the
+        lower 13 CPU address bus pins, VA13 is the inverted BLK4
+        address decoding bit.
     */
     mem_init(&sys->mem_vic);
-    mem_map_rom(&sys->mem_vic, 0, 0x0000, 0x1000, sys->rom_char);
-    mem_map_rom(&sys->mem_vic, 0, 0x1400, 0x0400, sys->color_ram);
-    mem_map_rom(&sys->mem_vic, 0, 0x2000, 0x0400, sys->ram0);
-    if (desc->mem_config >= VIC20_MEMCONFIG_8K) {
-        mem_map_rom(&sys->mem_vic, 0, 0x2400, 0x0C00, sys->ram_exp[0]);
+    mem_map_rom(&sys->mem_vic, 0, 0x0000, 0x1000, sys->rom_char);       /* CPU: 8000..8FFF */
+    mem_map_rom(&sys->mem_vic, 0, 0x1400, 0x0400, sys->color_ram);      /* CPU: 9400..97FF */
+    mem_map_rom(&sys->mem_vic, 0, 0x2000, 0x0400, sys->ram0);           /* CPU: 0000..03FF */
+    if (desc->mem_config == VIC20_MEMCONFIG_MAX) {
+        mem_map_rom(&sys->mem_vic, 0, 0x2400, 0x0C00, sys->ram_3k);     /* CPU: 0400..0FFF */
     }
-    mem_map_rom(&sys->mem_vic, 0, 0x3000, 0x1000, sys->ram1);
+    mem_map_rom(&sys->mem_vic, 0, 0x3000, 0x1000, sys->ram1);           /* CPU: 1000..1FFF */
 
     /*
         A special memory mapping used to copy ROM cartridge PRG files

--- a/systems/vic20.h
+++ b/systems/vic20.h
@@ -337,7 +337,8 @@ void vic20_init(vic20_t* sys, const vic20_desc_t* desc) {
     */
     mem_init(&sys->mem_vic);
     mem_map_rom(&sys->mem_vic, 0, 0x0000, 0x1000, sys->rom_char);       /* CPU: 8000..8FFF */
-    mem_map_rom(&sys->mem_vic, 0, 0x1400, 0x0400, sys->color_ram);      /* CPU: 9400..97FF */
+    // FIXME: can the VIC read the color RAM as data?
+    //mem_map_rom(&sys->mem_vic, 0, 0x1400, 0x0400, sys->color_ram);      /* CPU: 9400..97FF */
     mem_map_rom(&sys->mem_vic, 0, 0x2000, 0x0400, sys->ram0);           /* CPU: 0000..03FF */
     if (desc->mem_config == VIC20_MEMCONFIG_MAX) {
         mem_map_rom(&sys->mem_vic, 0, 0x2400, 0x0C00, sys->ram_3k);     /* CPU: 0400..0FFF */

--- a/systems/vic20.h
+++ b/systems/vic20.h
@@ -435,12 +435,7 @@ static uint64_t _vic20_tick(vic20_t* sys, uint64_t pins) {
         uint8_t via2_pb = ~jm;
         M6522_SET_PAB(via2_pins, via2_pa, via2_pb);
         via2_pins = m6522_tick(&sys->via_2, via2_pins);
-        if (via2_pins & M6522_IRQ) {
-            pins |= M6522_IRQ;
-        }
-        else {
-            pins &= ~M6522_IRQ;
-        }
+        pins = (pins & ~M6502_IRQ) | (via2_pins & M6522_IRQ);
         uint8_t kbd_cols = ~M6522_GET_PB(via2_pins);
         kbd_set_active_columns(&sys->kbd, kbd_cols);
     }

--- a/ui/ui_c1530.h
+++ b/ui/ui_c1530.h
@@ -1,0 +1,136 @@
+#pragma once
+/*#
+    # ui_c1530.h
+
+    Debugging UI for the c1530.h datassette drive emulation.
+
+    Do this:
+    ~~~C
+    #define CHIPS_IMPL
+    ~~~
+    before you include this file in *one* C++ file to create the 
+    implementation.
+
+    Optionally provide the following macros with your own implementation
+    
+    ~~~C
+    CHIPS_ASSERT(c)
+    ~~~
+        your own assert macro (default: assert(c))
+
+    Include the following headers (and their dependencies) before including
+    ui_c1530.h both for the declaration and implementation:
+
+    - c1530.h
+
+    ## zlib/libpng license
+
+    Copyright (c) 2020 Andre Weissflog
+    This software is provided 'as-is', without any express or implied warranty.
+    In no event will the authors be held liable for any damages arising from the
+    use of this software.
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+        1. The origin of this software must not be misrepresented; you must not
+        claim that you wrote the original software. If you use this software in a
+        product, an acknowledgment in the product documentation would be
+        appreciated but is not required.
+        2. Altered source versions must be plainly marked as such, and must not
+        be misrepresented as being the original software.
+        3. This notice may not be removed or altered from any source
+        distribution. 
+#*/
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* setup params for ui_c1530_init() */
+typedef struct {
+    const char* title;      /* window title */
+    c1530_t* c1530;         /* pointer to c1530_t instance */
+    int x, y;               /* initial window position */
+    int w, h;               /* initial window size, or 0 for default size */
+    bool open;              /* initial open state */
+} ui_c1530_desc_t;
+
+typedef struct {
+    const char* title;
+    c1530_t* c1530;
+    float init_x, init_y;
+    float init_w, init_h;
+    bool open;
+    bool valid;
+} ui_c1530_t;
+
+void ui_c1530_init(ui_c1530_t* win, const ui_c1530_desc_t* desc);
+void ui_c1530_discard(ui_c1530_t* win);
+void ui_c1530_draw(ui_c1530_t* win);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+/*-- IMPLEMENTATION (include in C++ source) ----------------------------------*/
+#ifdef CHIPS_IMPL
+#ifndef __cplusplus
+#error "implementation must be compiled as C++"
+#endif
+#include <string.h> /* memset */
+#ifndef CHIPS_ASSERT
+    #include <assert.h>
+    #define CHIPS_ASSERT(c) assert(c)
+#endif
+
+void ui_c1530_init(ui_c1530_t* win, const ui_c1530_desc_t* desc) {
+    CHIPS_ASSERT(win && desc);
+    CHIPS_ASSERT(desc->title);
+    CHIPS_ASSERT(desc->c1530);
+    memset(win, 0, sizeof(*win));
+    win->title = desc->title;
+    win->c1530 = desc->c1530;
+    win->init_x = (float) desc->x;
+    win->init_y = (float) desc->y;
+    win->init_w = (float) ((desc->w == 0) ? 200 : desc->w);
+    win->init_h = (float) ((desc->h == 0) ? 200 : desc->h);
+    win->open = desc->open;
+    win->valid = true;
+}
+
+void ui_c1530_discard(ui_c1530_t* win) {
+    CHIPS_ASSERT(win && win->valid);
+    win->valid = false;
+    win->c1530 = 0;
+}
+
+void ui_c1530_draw(ui_c1530_t* win) {
+    CHIPS_ASSERT(win && win->valid);
+    if (!win->open) {
+        return;
+    }
+    ImGui::SetNextWindowPos({win->init_x, win->init_y}, ImGuiCond_Once);
+    ImGui::SetNextWindowSize({win->init_w, win->init_h}, ImGuiCond_Once);
+    if (ImGui::Begin(win->title, &win->open)) {
+        c1530_t* sys = win->c1530;
+        CHIPS_ASSERT(sys && sys->cas_port);
+        if (ImGui::CollapsingHeader("Cassette Port", ImGuiTreeNodeFlags_DefaultOpen)) {
+            uint8_t cas_port = *sys->cas_port;
+            ImGui::Text("MOTOR: %d", (cas_port & VIC20_CASPORT_MOTOR) ? 1:0);
+            ImGui::Text("WRITE: %d", (cas_port & VIC20_CASPORT_WRITE) ? 1:0);
+            ImGui::Text("READ:  %d", (cas_port & VIC20_CASPORT_READ) ? 1:0);
+            ImGui::Text("SENSE: %d", (cas_port & VIC20_CASPORT_SENSE) ? 1:0);
+        }
+        if (ImGui::CollapsingHeader("Drive Status", ImGuiTreeNodeFlags_DefaultOpen)) {
+            ImGui::Text("Motor: %s", c1530_is_motor_on(sys) ? "ON":"OFF");
+            ImGui::Text("Tape:  %s", c1530_tape_inserted(sys) ? "INSERTED":"NONE");
+            ImGui::Text("Pos:   %d/%d", sys->pos, sys->size);
+            ImGui::Text("Pulse Count: %d", sys->pulse_count);
+        }
+    }
+    ImGui::End();
+}
+
+#endif /* CHIPS_IMPL */

--- a/ui/ui_c1530.h
+++ b/ui/ui_c1530.h
@@ -95,7 +95,7 @@ void ui_c1530_init(ui_c1530_t* win, const ui_c1530_desc_t* desc) {
     win->init_x = (float) desc->x;
     win->init_y = (float) desc->y;
     win->init_w = (float) ((desc->w == 0) ? 200 : desc->w);
-    win->init_h = (float) ((desc->h == 0) ? 200 : desc->h);
+    win->init_h = (float) ((desc->h == 0) ? 220 : desc->h);
     win->open = desc->open;
     win->valid = true;
 }

--- a/ui/ui_m6522.h
+++ b/ui/ui_m6522.h
@@ -150,12 +150,12 @@ static void _ui_m6522_draw_ports(ui_m6522_t* win) {
         ui_util_b8("PA DDR:  ", via->pa.ddr);  ImGui::SameLine(); ImGui::Text("(%02X)", via->pa.ddr);
         ui_util_b8("PA Inp:  ", via->pa.inpr); ImGui::SameLine(); ImGui::Text("(%02X)", via->pa.inpr);
         ui_util_b8("PA Out:  ", via->pa.outr); ImGui::SameLine(); ImGui::Text("(%02X)", via->pa.outr);
-        ui_util_b8("PA Port: ", via->pa.port); ImGui::SameLine(); ImGui::Text("(%02X)", via->pa.port);
+        ui_util_b8("PA Pins: ", via->pa.pins); ImGui::SameLine(); ImGui::Text("(%02X)", via->pa.pins);
         ImGui::Separator();
         ui_util_b8("PB DDR:  ", via->pb.ddr);  ImGui::SameLine(); ImGui::Text("(%02X)", via->pb.ddr);
         ui_util_b8("PB Inp:  ", via->pb.inpr); ImGui::SameLine(); ImGui::Text("(%02X)", via->pb.inpr);
         ui_util_b8("PB Out:  ", via->pb.outr); ImGui::SameLine(); ImGui::Text("(%02X)", via->pb.outr);
-        ui_util_b8("PB Port: ", via->pb.port); ImGui::SameLine(); ImGui::Text("(%02X)", via->pb.port);
+        ui_util_b8("PB Pins: ", via->pb.pins); ImGui::SameLine(); ImGui::Text("(%02X)", via->pb.pins);
     }
 }
 

--- a/ui/ui_m6522.h
+++ b/ui/ui_m6522.h
@@ -151,11 +151,15 @@ static void _ui_m6522_draw_ports(ui_m6522_t* win) {
         ui_util_b8("PA Inp:  ", via->pa.inpr); ImGui::SameLine(); ImGui::Text("(%02X)", via->pa.inpr);
         ui_util_b8("PA Out:  ", via->pa.outr); ImGui::SameLine(); ImGui::Text("(%02X)", via->pa.outr);
         ui_util_b8("PA Pins: ", via->pa.pins); ImGui::SameLine(); ImGui::Text("(%02X)", via->pa.pins);
+        ImGui::Text("PA C1:   in=%s, out=%s", via->pa.c1_in?"ON ":"OFF", via->pa.c1_out?"ON ":"OFF");
+        ImGui::Text("PA C2:   in=%s, out=%s", via->pa.c2_in?"ON ":"OFF", via->pa.c2_out?"ON ":"OFF");
         ImGui::Separator();
         ui_util_b8("PB DDR:  ", via->pb.ddr);  ImGui::SameLine(); ImGui::Text("(%02X)", via->pb.ddr);
         ui_util_b8("PB Inp:  ", via->pb.inpr); ImGui::SameLine(); ImGui::Text("(%02X)", via->pb.inpr);
         ui_util_b8("PB Out:  ", via->pb.outr); ImGui::SameLine(); ImGui::Text("(%02X)", via->pb.outr);
         ui_util_b8("PB Pins: ", via->pb.pins); ImGui::SameLine(); ImGui::Text("(%02X)", via->pb.pins);
+        ImGui::Text("PB C1:   in=%s, out=%s", via->pb.c1_in?"ON ":"OFF", via->pb.c1_out?"ON ":"OFF");
+        ImGui::Text("PB C2:   in=%s, out=%s", via->pb.c2_in?"ON ":"OFF", via->pb.c2_out?"ON ":"OFF");
     }
 }
 

--- a/ui/ui_m6522.h
+++ b/ui/ui_m6522.h
@@ -241,7 +241,7 @@ void ui_m6522_draw(ui_m6522_t* win) {
     ImGui::SetNextWindowSize(ImVec2(win->init_w, win->init_h), ImGuiCond_Once);
     if (ImGui::Begin(win->title, &win->open)) {
         ImGui::BeginChild("##m6522_chip", ImVec2(176, 0), true);
-        ui_chip_draw(&win->chip, win->via->iorq_pins);
+        ui_chip_draw(&win->chip, win->via->pins);
         ImGui::EndChild();
         ImGui::SameLine();
         ImGui::BeginChild("##m6522_state", ImVec2(0, 0), true);

--- a/ui/ui_vic20.h
+++ b/ui/ui_vic20.h
@@ -66,6 +66,7 @@ typedef void (*ui_vic20_boot_cb)(vic20_t* sys);
 /* setup params for ui_c64_init() */
 typedef struct {
     vic20_t* vic20;             /* pointer to vic20_t instance to track */
+    c1530_t* c1530;             /* optional pointer to datasette instance */
     ui_vic20_boot_cb boot_cb;   /* reboot callback function */
     ui_dbg_create_texture_t create_texture_cb;      /* texture creation callback for ui_dbg_t */
     ui_dbg_update_texture_t update_texture_cb;      /* texture update callback for ui_dbg_t */
@@ -75,6 +76,7 @@ typedef struct {
 
 typedef struct {
     vic20_t* vic20;
+    c1530_t* c1530;
     int dbg_scanline;
     ui_vic20_boot_cb boot_cb;
     ui_m6502_t cpu;
@@ -86,6 +88,7 @@ typedef struct {
     ui_memedit_t memedit[4];
     ui_dasm_t dasm[4];
     ui_dbg_t dbg;
+    bool system_window_open;
 } ui_vic20_t;
 
 void ui_vic20_init(ui_vic20_t* ui, const ui_vic20_desc_t* desc);
@@ -140,6 +143,7 @@ static void _ui_vic20_draw_menu(ui_vic20_t* ui, double time_ms) {
             ImGui::EndMenu();
         }
         if (ImGui::BeginMenu("Hardware")) {
+            ImGui::MenuItem("System", 0, &ui->system_window_open);
             ImGui::MenuItem("Memory Map", 0, &ui->memmap.open);
             ImGui::MenuItem("Keyboard Matrix", 0, &ui->kbd.open);
             ImGui::MenuItem("Audio Output", 0, &ui->audio.open);
@@ -332,6 +336,7 @@ static const ui_chip_pin_t _ui_vic20_via_pins[] = {
     { "RW",     14,     M6522_RW },
     { "CS1",    15,     M6522_CS1 },
     { "CS2",    16,     M6522_CS2 },
+    { "IRQ",    17,     M6522_IRQ },
     { "PA0",    20,     M6522_PA0 },
     { "PA1",    21,     M6522_PA1 },
     { "PA2",    22,     M6522_PA2 },
@@ -385,6 +390,7 @@ void ui_vic20_init(ui_vic20_t* ui, const ui_vic20_desc_t* ui_desc) {
     CHIPS_ASSERT(ui_desc->vic20);
     CHIPS_ASSERT(ui_desc->boot_cb);
     ui->vic20 = ui_desc->vic20;
+    ui->c1530 = ui_desc->c1530;
     ui->boot_cb = ui_desc->boot_cb;
     int x = 20, y = 20, dx = 10, dy = 10;
     {
@@ -529,12 +535,46 @@ void ui_vic20_discard(ui_vic20_t* ui) {
     ui_dbg_discard(&ui->dbg);
 }
 
+void ui_vic20_draw_system(ui_vic20_t* ui) {
+    if (!ui->system_window_open) {
+        return;
+    }
+    vic20_t* sys = ui->vic20;
+    ImGui::SetNextWindowSize({ 200, 250}, ImGuiCond_Once);
+    if (ImGui::Begin("VIC-20 System", &ui->system_window_open)) {
+        const char* mem_config = "???";
+        switch (sys->mem_config) {
+            case VIC20_MEMCONFIG_STANDARD:  mem_config = "standard"; break;
+            case VIC20_MEMCONFIG_8K:        mem_config = "+8K RAM"; break;
+            case VIC20_MEMCONFIG_16K:       mem_config = "+16K RAM"; break;
+            case VIC20_MEMCONFIG_24K:       mem_config = "+24K RAM"; break;
+            case VIC20_MEMCONFIG_32K:       mem_config = "+32K RAM"; break;
+        }
+        ImGui::Text("Memory Config: %s", mem_config);
+        if (ImGui::CollapsingHeader("Cassette Port", ImGuiTreeNodeFlags_DefaultOpen)) {
+            ImGui::Text("MOTOR: %d", (sys->cas_port & VIC20_CASPORT_MOTOR) ? 1:0);
+            ImGui::Text("WRITE: %d", (sys->cas_port & VIC20_CASPORT_WRITE) ? 1:0);
+            ImGui::Text("READ:  %d", (sys->cas_port & VIC20_CASPORT_READ) ? 1:0);
+            ImGui::Text("SENSE: %d", (sys->cas_port & VIC20_CASPORT_SENSE) ? 1:0);
+        }
+        if (ImGui::CollapsingHeader("IEC Port", ImGuiTreeNodeFlags_DefaultOpen)) {
+            ImGui::Text("RESET: %d", (sys->iec_port & VIC20_IECPORT_RESET) ? 1:0);
+            ImGui::Text("SRQIN: %d", (sys->iec_port & VIC20_IECPORT_SRQIN) ? 1:0);
+            ImGui::Text("DATA:  %d", (sys->iec_port & VIC20_IECPORT_DATA) ? 1:0);
+            ImGui::Text("CLK:   %d", (sys->iec_port & VIC20_IECPORT_CLK) ? 1:0);
+            ImGui::Text("ATN:   %d", (sys->iec_port & VIC20_IECPORT_ATN) ? 1:0);
+        }
+    }
+    ImGui::End();
+}
+
 void ui_vic20_draw(ui_vic20_t* ui, double time_ms) {
     CHIPS_ASSERT(ui && ui->vic20);
     _ui_vic20_draw_menu(ui, time_ms);
     if (ui->memmap.open) {
         _ui_vic20_update_memmap(ui);
     }
+    ui_vic20_draw_system(ui);
     ui_audio_draw(&ui->audio, ui->vic20->sample_pos);
     ui_kbd_draw(&ui->kbd);
     ui_m6502_draw(&ui->cpu);
@@ -553,10 +593,24 @@ void ui_vic20_exec(ui_vic20_t* ui, uint32_t frame_time_us) {
     CHIPS_ASSERT(ui && ui->vic20);
     uint32_t ticks_to_run = clk_us_to_ticks(VIC20_FREQUENCY, frame_time_us);
     vic20_t* vic20 = ui->vic20;
-    for (uint32_t i = 0; (i < ticks_to_run) && (!ui->dbg.dbg.stopped); i++) {
-        vic20_tick(vic20);
-        if (vic20->pins & M6502_SYNC) {
-            ui_dbg_after_instr(&ui->dbg, vic20->pins, (uint32_t)vic20->cpu.ticks);
+    c1530_t* c1530 = ui->c1530;
+    if (c1530) {
+        /* tick VIC20 and datasette */
+        for (uint32_t i = 0; (i < ticks_to_run) && (!ui->dbg.dbg.stopped); i++) {
+            vic20_tick(vic20);
+            c1530_tick(c1530);
+            if (vic20->pins & M6502_SYNC) {
+                ui_dbg_after_instr(&ui->dbg, vic20->pins, (uint32_t)vic20->cpu.ticks);
+            }
+        }
+    }
+    else {
+        /* no peripherals connected, only tick VIC20 */
+        for (uint32_t i = 0; (i < ticks_to_run) && (!ui->dbg.dbg.stopped); i++) {
+            vic20_tick(vic20);
+            if (vic20->pins & M6502_SYNC) {
+                ui_dbg_after_instr(&ui->dbg, vic20->pins, (uint32_t)vic20->cpu.ticks);
+            }
         }
     }
     kbd_update(&ui->vic20->kbd);


### PR DESCRIPTION
- the separate m6522_iorq() call has been merged into m6522_tick()
- all I/O callback functions have been removed
- implement CA/CB pins behaviour
- various VIA timer fixes
- various VIC-20 emulation fixes