### PR TITLE
c1530, c1541, cycle debugging

### DIFF
--- a/chips/m6502.h
+++ b/chips/m6502.h
@@ -296,7 +296,6 @@ typedef struct {
     uint16_t nmi_pip;
     uint8_t brk_flags;  /* M6502_BRK_* */
     uint8_t bcd_enabled;
-    uint64_t ticks;     /* tick counter (only for inspection) */
     /* 6510 IO port state */
     void* user_data;
     m6510_in_t in_cb;
@@ -650,7 +649,6 @@ uint64_t m6510_iorq(m6502_t* c, uint64_t pins) {
 #endif
 
 uint64_t m6502_tick(m6502_t* c, uint64_t pins) {
-    c->ticks++;
     if (pins & (M6502_SYNC|M6502_IRQ|M6502_NMI|M6502_RDY|M6502_RES)) {
         // interrupt detection also works in RDY phases, but only NMI is "sticky"
         

--- a/codegen/m6502.template.h
+++ b/codegen/m6502.template.h
@@ -296,7 +296,6 @@ typedef struct {
     uint16_t nmi_pip;
     uint8_t brk_flags;  /* M6502_BRK_* */
     uint8_t bcd_enabled;
-    uint64_t ticks;     /* tick counter (only for inspection) */
     /* 6510 IO port state */
     void* user_data;
     m6510_in_t in_cb;
@@ -650,7 +649,6 @@ uint64_t m6510_iorq(m6502_t* c, uint64_t pins) {
 #endif
 
 uint64_t m6502_tick(m6502_t* c, uint64_t pins) {
-    c->ticks++;
     if (pins & (M6502_SYNC|M6502_IRQ|M6502_NMI|M6502_RDY|M6502_RES)) {
         // interrupt detection also works in RDY phases, but only NMI is "sticky"
         

--- a/ui/ui_atom.h
+++ b/ui/ui_atom.h
@@ -503,9 +503,7 @@ void ui_atom_exec(ui_atom_t* ui, uint32_t frame_time_us) {
     atom_t* atom = ui->atom;
     for (uint32_t i = 0; (i < ticks_to_run) && (!ui->dbg.dbg.stopped); i++) {
         atom_tick(ui->atom);
-        if (atom->pins & M6502_SYNC) {
-            ui_dbg_after_instr(&ui->dbg, atom->pins, (uint32_t)atom->cpu.ticks);
-        }
+        ui_dbg_tick(&ui->dbg, atom->pins);
     }
     kbd_update(&ui->atom->kbd);
 }

--- a/ui/ui_c64.h
+++ b/ui/ui_c64.h
@@ -754,9 +754,7 @@ void ui_c64_exec(ui_c64_t* ui, uint32_t frame_time_us) {
     c64_t* c64 = ui->c64;
     for (uint32_t i = 0; (i < ticks_to_run) && (!ui->dbg.dbg.stopped); i++) {
         c64_tick(c64);
-        if (c64->pins & M6502_SYNC) {
-            ui_dbg_after_instr(&ui->dbg, c64->pins, (uint32_t)c64->cpu.ticks);
-        }
+        ui_dbg_tick(&ui->dbg, c64->pins);
     }
     kbd_update(&ui->c64->kbd);
 }

--- a/ui/ui_c64.h
+++ b/ui/ui_c64.h
@@ -69,8 +69,6 @@ typedef void (*ui_c64_boot_cb)(c64_t* sys);
 /* setup params for ui_c64_init() */
 typedef struct {
     c64_t* c64;             /* pointer to c64_t instance to track */
-    c1530_t* c1530;         /* optional pointer to datasette instance */
-    c1541_t* c1541;         /* optional pointer to 1541 instance (mutual exclusive with c1530) */
     ui_c64_boot_cb boot_cb; /* reboot callback function */
     ui_dbg_create_texture_t create_texture_cb;      /* texture creation callback for ui_dbg_t */
     ui_dbg_update_texture_t update_texture_cb;      /* texture update callback for ui_dbg_t */
@@ -80,8 +78,6 @@ typedef struct {
 
 typedef struct {
     c64_t* c64;
-    c1530_t* c1530;
-    c1541_t* c1541;
     int dbg_scanline;
     ui_c64_boot_cb boot_cb;
     ui_m6502_t cpu;
@@ -129,14 +125,14 @@ static void _ui_c64_draw_menu(ui_c64_t* ui, double time_ms) {
             if (ImGui::MenuItem("Reset")) {
                 c64_reset(ui->c64);
                 ui_dbg_reset(&ui->dbg);
-                if (ui->c1541) {
+                if (ui->c64->c1541.valid) {
                     ui_dbg_reset(&ui->c1541_dbg);
                 }
             }
             if (ImGui::MenuItem("Cold Boot")) {
                 ui->boot_cb(ui->c64);
                 ui_dbg_reboot(&ui->dbg);
-                if (ui->c1541) {
+                if (ui->c64->c1541.valid) {
                     ui_dbg_reboot(&ui->c1541_dbg);
                 }
             }
@@ -163,7 +159,7 @@ static void _ui_c64_draw_menu(ui_c64_t* ui, double time_ms) {
             ImGui::MenuItem("MOS 6526 #2 (CIA)", 0, &ui->cia[1].open);
             ImGui::MenuItem("MOS 6581 (SID)", 0, &ui->sid.open);
             ImGui::MenuItem("MOS 6569 (VIC-II)", 0, &ui->vic.open);
-            if (ui->c1541) {
+            if (ui->c64->c1541.valid) {
                 if (ImGui::BeginMenu("VC-1541 (Floppy Drive)")) {
                     ImGui::MenuItem("MOS 6502 (CPU)", 0, &ui->c1541_cpu.open);
                     ImGui::EndMenu();
@@ -190,7 +186,7 @@ static void _ui_c64_draw_menu(ui_c64_t* ui, double time_ms) {
                 ImGui::MenuItem("Window #4", 0, &ui->dasm[3].open);
                 ImGui::EndMenu();
             }
-            if (ui->c1541) {
+            if (ui->c64->c1541.valid) {
                 if (ImGui::BeginMenu("VC-1541 (Floppy Drive)")) {
                     ImGui::MenuItem("CPU Debugger", 0, &ui->c1541_dbg.ui.open);
                     ImGui::MenuItem("Breakpoints", 0, &ui->c1541_dbg.ui.show_breakpoints);
@@ -222,15 +218,14 @@ static const char* _ui_c64_memlayer_names[_UI_C64_MEMLAYER_NUM] = {
 
 static uint8_t _ui_c64_c1541_mem_read(int layer, uint16_t addr, void* user_data) {
     ui_c64_t* ui = (ui_c64_t*) user_data;
-    CHIPS_ASSERT(ui && ui->c1541);
-    return mem_rd(&ui->c1541->mem, addr);
+    CHIPS_ASSERT(ui && ui->c64->c1541.valid);
+    return mem_rd(&ui->c64->c1541.mem, addr);
 }
 
 static uint8_t _ui_c64_mem_read(int layer, uint16_t addr, void* user_data) {
     CHIPS_ASSERT(user_data);
     ui_c64_t* ui = (ui_c64_t*) user_data;
     c64_t* c64 = ui->c64;
-    c1541_t* c1541 = ui->c1541;
     switch (layer) {
         case _UI_C64_MEMLAYER_CPU:
             return mem_rd(&c64->mem_cpu, addr);
@@ -254,8 +249,8 @@ static uint8_t _ui_c64_mem_read(int layer, uint16_t addr, void* user_data) {
             }
             break;
         case _UI_C64_MEMLAYER_1541:
-            if (c1541) {
-                return mem_rd(&c1541->mem, addr);
+            if (ui->c64->c1541.valid) {
+                return mem_rd(&ui->c64->c1541.mem, addr);
             }
             else {
                 return 0xFF;
@@ -280,7 +275,6 @@ static void _ui_c64_mem_write(int layer, uint16_t addr, uint8_t data, void* user
     CHIPS_ASSERT(user_data);
     ui_c64_t* ui = (ui_c64_t*) user_data;
     c64_t* c64 = ui->c64;
-    c1541_t* c1541 = ui->c1541;
     switch (layer) {
         case _UI_C64_MEMLAYER_CPU:
             mem_wr(&c64->mem_cpu, addr, data);
@@ -303,8 +297,8 @@ static void _ui_c64_mem_write(int layer, uint16_t addr, uint8_t data, void* user
             }
             break;
         case _UI_C64_MEMLAYER_1541:
-            if (c1541) {
-                mem_wr(&c1541->mem, addr, data);
+            if (ui->c64->c1541.valid) {
+                mem_wr(&ui->c64->c1541.mem, addr, data);
             }
             break;
         case _UI_C64_MEMLAYER_VIC:
@@ -543,8 +537,6 @@ void ui_c64_init(ui_c64_t* ui, const ui_c64_desc_t* ui_desc) {
     CHIPS_ASSERT(ui_desc->c64);
     CHIPS_ASSERT(ui_desc->boot_cb);
     ui->c64 = ui_desc->c64;
-    ui->c1530 = ui_desc->c1530;
-    ui->c1541 = ui_desc->c1541;
     ui->boot_cb = ui_desc->boot_cb;
     int x = 20, y = 20, dx = 10, dy = 10;
     {
@@ -567,10 +559,10 @@ void ui_c64_init(ui_c64_t* ui, const ui_c64_desc_t* ui_desc) {
         desc.user_breaktypes[2].label = "Next Badline";
         desc.user_breaktypes[3].label = "Next Frame";
         ui_dbg_init(&ui->dbg, &desc);
-        if (ui->c1541) {
+        if (ui->c64->c1541.valid) {
             x += dx; y += dy;
             desc.title = "CPU Debugger (1541 Floppy)";
-            desc.m6502 = &ui->c1541->cpu;
+            desc.m6502 = &ui->c64->c1541.cpu;
             desc.x = x;
             desc.y = y;
             desc.read_cb = _ui_c64_c1541_mem_read;
@@ -593,11 +585,11 @@ void ui_c64_init(ui_c64_t* ui, const ui_c64_desc_t* ui_desc) {
         UI_CHIP_INIT_DESC(&desc.chip_desc, "6510", 40, _ui_c64_cpu6510_pins);
         ui_m6502_init(&ui->cpu, &desc);
     }
-    if (ui->c1541) {
+    if (ui->c64->c1541.valid) {
         x += dx; y += dy;
         ui_m6502_desc_t desc = {0};
         desc.title = "MOS 6502 (1541 Floppy Drive)";
-        desc.cpu = &ui->c1541->cpu;
+        desc.cpu = &ui->c64->c1541.cpu;
         desc.x = x;
         desc.y = y;
         desc.h = 390;
@@ -707,9 +699,8 @@ void ui_c64_init(ui_c64_t* ui, const ui_c64_desc_t* ui_desc) {
 
 void ui_c64_discard(ui_c64_t* ui) {
     CHIPS_ASSERT(ui && ui->c64);
-    ui->c64 = 0;
     ui_m6502_discard(&ui->cpu);
-    if (ui->c1541) {
+    if (ui->c64->c1541.valid) {
         ui_m6502_discard(&ui->c1541_cpu);
     }
     ui_m6526_discard(&ui->cia[0]);
@@ -724,9 +715,10 @@ void ui_c64_discard(ui_c64_t* ui) {
         ui_dasm_discard(&ui->dasm[i]);
     }
     ui_dbg_discard(&ui->dbg);
-    if (ui->c1541) {
+    if (ui->c64->c1541.valid) {
         ui_dbg_discard(&ui->c1541_dbg);
     }
+    ui->c64 = 0;
 }
 
 void ui_c64_draw(ui_c64_t* ui, double time_ms) {
@@ -738,7 +730,7 @@ void ui_c64_draw(ui_c64_t* ui, double time_ms) {
     ui_audio_draw(&ui->audio, ui->c64->sample_pos);
     ui_kbd_draw(&ui->kbd);
     ui_m6502_draw(&ui->cpu);
-    if (ui->c1541) {
+    if (ui->c64->c1541.valid) {
         ui_m6502_draw(&ui->c1541_cpu);
     }
     ui_m6526_draw(&ui->cia[0]);
@@ -751,7 +743,7 @@ void ui_c64_draw(ui_c64_t* ui, double time_ms) {
         ui_dasm_draw(&ui->dasm[i]);
     }
     ui_dbg_draw(&ui->dbg);
-    if (ui->c1541) {
+    if (ui->c64->c1541.valid) {
         ui_dbg_draw(&ui->c1541_dbg);
     }
 }
@@ -760,38 +752,10 @@ void ui_c64_exec(ui_c64_t* ui, uint32_t frame_time_us) {
     CHIPS_ASSERT(ui && ui->c64);
     uint32_t ticks_to_run = clk_us_to_ticks(C64_FREQUENCY, frame_time_us);
     c64_t* c64 = ui->c64;
-    c1530_t* c1530 = ui->c1530;
-    c1541_t* c1541 = ui->c1541;
-    if (c1530) {
-        /* tick C64 and datasette */
-        for (uint32_t i = 0; (i < ticks_to_run) && (!ui->dbg.dbg.stopped); i++) {
-            c64_tick(c64);
-            c1530_tick(c1530);
-            if (c64->pins & M6502_SYNC) {
-                ui_dbg_after_instr(&ui->dbg, c64->pins, (uint32_t)c64->cpu.ticks);
-            }
-        }
-    }
-    else if (c1541) {
-        /* tick C64 and 1541 (FIXME: is it ok to tick both at the same speed?) */
-        for (uint32_t i = 0; (i < ticks_to_run) && !(ui->dbg.dbg.stopped || ui->c1541_dbg.dbg.stopped); i++) {
-            c64_tick(c64);
-            c1541_tick(c1541);
-            if (c64->pins & M6502_SYNC) {
-                ui_dbg_after_instr(&ui->dbg, c64->pins, (uint32_t)c64->cpu.ticks);
-            }
-            if (c1541->pins & M6502_SYNC) {
-                ui_dbg_after_instr(&ui->c1541_dbg, c1541->pins, (uint32_t)c1541->cpu.ticks);
-            }
-        }
-    }
-    else {
-        /* no peripherals connected, only tick C64 */
-        for (uint32_t i = 0; (i < ticks_to_run) && (!ui->dbg.dbg.stopped); i++) {
-            c64_tick(c64);
-            if (c64->pins & M6502_SYNC) {
-                ui_dbg_after_instr(&ui->dbg, c64->pins, (uint32_t)c64->cpu.ticks);
-            }
+    for (uint32_t i = 0; (i < ticks_to_run) && (!ui->dbg.dbg.stopped); i++) {
+        c64_tick(c64);
+        if (c64->pins & M6502_SYNC) {
+            ui_dbg_after_instr(&ui->dbg, c64->pins, (uint32_t)c64->cpu.ticks);
         }
     }
     kbd_update(&ui->c64->kbd);

--- a/ui/ui_vic20.h
+++ b/ui/ui_vic20.h
@@ -608,9 +608,7 @@ void ui_vic20_exec(ui_vic20_t* ui, uint32_t frame_time_us) {
     vic20_t* vic20 = ui->vic20;
     for (uint32_t i = 0; (i < ticks_to_run) && (!ui->dbg.dbg.stopped); i++) {
         vic20_tick(vic20);
-        if (vic20->pins & M6502_SYNC) {
-            ui_dbg_after_instr(&ui->dbg, vic20->pins, (uint32_t)vic20->cpu.ticks);
-        }
+        ui_dbg_tick(&ui->dbg, vic20->pins);
     }
     kbd_update(&ui->vic20->kbd);
 }


### PR DESCRIPTION
Integrates c1530.h and the (incomplete) c1541.h back into the emulated systems (c64.h and vic20.h) in order to simplify ticking the systems. Then implements single-tick-stepping in ui_dbg.h for m6502 based systems (c64.h, vic20.h and atom.h)