### PR TITLE
iorq() -> tick() merge for CIA, VIC-II and SID

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ For schematics, manuals and research material, see: https://github.com/floooh/em
 
 ## What's New
 
+* **15-Jan-2020**: The CIA (m6526.h), VIC-II (m6569.h), SID (m6581.h) chip
+    emulators have merged their *_iorq() functions for reading
+    and writing chip registers into the regular *_tick() functions,
+    and the C64 emulation in systems/c64.h has been updated accordingly
+    (this API change started with the chips in the vic20.h and will continue for 
+    the other chip emulators).
+
 * **03-Jan-2020**: Another VIA- and VIC-20 related update:
     - The VIA (m6522.h) API has been simplified: the separate m6522_iorq()
       function to read and write chip registers has been merged into

--- a/chips/m6522.h
+++ b/chips/m6522.h
@@ -851,6 +851,7 @@ uint64_t m6522_tick(m6522_t* c, uint64_t pins) {
             _m6522_write(c, addr, data);
         }
     }
+    /* FIXME: move tick above read/write? */
     pins = _m6522_tick(c, pins);
     c->pins = pins;
     return pins;

--- a/chips/m6561.h
+++ b/chips/m6561.h
@@ -559,7 +559,7 @@ static inline float _m6561_dcadjust(m6561_sound_t* snd, float s) {
 }
 
 /* tick the audio engine, return true if a new sample if ready */
-static bool _m6561_tick_audio(m6561_t* vic) {
+static uint64_t _m6561_tick_audio(m6561_t* vic, uint64_t pins) {
     m6561_sound_t* snd = &vic->sound;
     /* tick tone voices */
     for (int i = 0; i < 3; i++) {
@@ -605,11 +605,12 @@ static bool _m6561_tick_audio(m6561_t* vic) {
         snd->sample_accum = 0.0f;
         snd->sample_accum_count = 0.0f;
         snd->sample = _m6561_dcadjust(snd, sm) * snd->sample_mag;
-        return true;
+        pins |= M6561_SAMPLE;
     }
     else {
-        return false;
+        pins &= ~M6561_SAMPLE;
     }
+    return pins;
 }
 
 /* chip-selected macro (A12 must be active in A8..A13) */
@@ -646,10 +647,7 @@ uint64_t m6561_tick(m6561_t* vic, uint64_t pins) {
 
     /* perform per-tick actions */
     _m6561_tick_video(vic);
-    pins &= ~M6561_SAMPLE;
-    if (_m6561_tick_audio(vic)) {
-        pins |= M6561_SAMPLE;
-    }
+    pins = _m6561_tick_audio(vic, pins);
     vic->pins = pins;
     return pins;
 }

--- a/chips/m6581.h
+++ b/chips/m6581.h
@@ -627,7 +627,7 @@ static inline int _m6581_filter_output(m6581_filter_t* f, int vi) {
 }
 
 /* tick the sound generation, return true when new sample ready */
-static bool _m6581_tick(m6581_t* sid) {
+static uint64_t _m6581_tick(m6581_t* sid, uint64_t pins) {
     /* decay the last written register value */
     if (sid->bus_decay > 0) {
         if (--sid->bus_decay == 0) {
@@ -675,11 +675,12 @@ static bool _m6581_tick(m6581_t* sid) {
         sid->sample = sid->sample_mag * s;
         sid->sample_accum = 0.0f;
         sid->sample_accum_count = 0.0f;
-        return true;
+        pins |= M6581_SAMPLE;
     }
     else {
-        return false;
+        pins &= ~M6581_SAMPLE;
     }
+    return pins;
 }
 
 /* read a register */
@@ -800,10 +801,7 @@ uint64_t m6581_tick(m6581_t* sid, uint64_t pins) {
     CHIPS_ASSERT(sid);
 
     /* first perform the regular per-tick actions */
-    if (_m6581_tick(sid)) {
-        /* new audio sample is ready */
-        pins |= M6581_SAMPLE;
-    }
+    pins = _m6581_tick(sid, pins);
 
     /* register read/write */
     if (pins & M6581_CS) {

--- a/chips/m6581.h
+++ b/chips/m6581.h
@@ -30,10 +30,11 @@
     *           |           |...      *
     *           |           |<--> D7  *
     *           |           |         *
-    *           +-----------+         *§
+    *           +-----------+         *
     ***********************************
 
-    TODO: Documentation
+    The emulation has an additional "virtual pin" which is set to active
+    whenever a new sample is ready (M6581_SAMPLE).
 
     ## Links
 
@@ -86,7 +87,8 @@ extern "C" {
 #define M6581_RW    (1ULL<<24)      /* same as M6502_RW */
 
 /* chip-specific pins */
-#define M6581_CS    (1ULL<<40)      /* chip-select */
+#define M6581_CS        (1ULL<<40)      /* chip-select */
+#define M6581_SAMPLE    (1ULL<<41)      /* virtual "audio sample ready" pin */
 
 /* registers */
 #define M6581_V1_FREQ_LO    (0)
@@ -226,10 +228,8 @@ typedef struct {
 void m6581_init(m6581_t* sid, const m6581_desc_t* desc);
 /* reset a m6581_t instance */
 void m6581_reset(m6581_t* sid);
-/* read/write m6581_t registers */
-uint64_t m6581_iorq(m6581_t* sid, uint64_t pins);
-/* tick a m6581_t instance, returns true when new sample is ready */
-bool m6581_tick(m6581_t* sid);
+/* tick a m6581_t instance */
+uint64_t m6581_tick(m6581_t* sid, uint64_t pins);
 
 #ifdef __cplusplus
 } /* extern "C" */
@@ -626,10 +626,8 @@ static inline int _m6581_filter_output(m6581_filter_t* f, int vi) {
     return vf * (1<<7);
 }
 
-/*--- TICK FUNCTION ----------------------------------------------------------*/
-bool m6581_tick(m6581_t* sid) {
-    CHIPS_ASSERT(sid);
-
+/* tick the sound generation, return true when new sample ready */
+static bool _m6581_tick(m6581_t* sid) {
     /* decay the last written register value */
     if (sid->bus_decay > 0) {
         if (--sid->bus_decay == 0) {
@@ -684,119 +682,140 @@ bool m6581_tick(m6581_t* sid) {
     }
 }
 
-uint64_t m6581_iorq(m6581_t* sid, uint64_t pins) {
-    CHIPS_ASSERT(sid);
-    if (pins & M6581_CS) {
-        uint8_t addr = pins & M6581_ADDR_MASK;
-        if (pins & M6581_RW) {
-            uint8_t data;
-            switch (addr) {
-                case M6581_POT_X:
-                case M6581_POT_Y:
-                    /* FIXME: potentiometers */
-                    data = 0;
-                    sid->bus_value = 0;
-                    break;
-                case M6581_OSC3RAND:
-                    /* FIXME */
-                    sid->bus_value = 0;
-                    data = sid->voice[2].wav_output >> 4;
-                    break;
-                case M6581_ENV3:
-                    sid->bus_value = 0;
-                    data = sid->voice[2].env_cur_level;
-                    break;
-                default:
-                    data = sid->bus_value;
-                    break;
-            }
-            M6581_SET_DATA(pins, data);
-        }
-        else {
-            /* write access (only voice and filter regs) */
-            uint8_t data = M6581_GET_DATA(pins);
-            sid->bus_value = data;
-            sid->bus_decay = 0x2000;
-            switch (addr) {
-                case M6581_V1_FREQ_LO:
-                    _m6581_set_freq_lo(&sid->voice[0], data);
-                    break;
-                case M6581_V1_FREQ_HI:
-                    _m6581_set_freq_hi(&sid->voice[0], data);
-                    break;
-                case M6581_V1_PW_LO:
-                    _m6581_set_pw_lo(&sid->voice[0], data);
-                    break;
-                case M6581_V1_PW_HI:
-                    _m6581_set_pw_hi(&sid->voice[0], data);
-                    break;
-                case M6581_V1_CTRL:
-                    _m6581_set_ctrl(&sid->voice[0], data);
-                    break;
-                case M6581_V1_ATKDEC:
-                    _m6581_set_atkdec(&sid->voice[0], data);
-                    break;
-                case M6581_V1_SUSREL:
-                    _m6581_set_susrel(&sid->voice[0], data);
-                    break;
-                case M6581_V2_FREQ_LO:
-                    _m6581_set_freq_lo(&sid->voice[1], data);
-                    break;
-                case M6581_V2_FREQ_HI:
-                    _m6581_set_freq_hi(&sid->voice[1], data);
-                    break;
-                case M6581_V2_PW_LO:
-                    _m6581_set_pw_lo(&sid->voice[1], data);
-                    break;
-                case M6581_V2_PW_HI:
-                    _m6581_set_pw_hi(&sid->voice[1], data);
-                    break;
-                case M6581_V2_CTRL:
-                    _m6581_set_ctrl(&sid->voice[1], data);
-                    break;
-                case M6581_V2_ATKDEC:
-                    _m6581_set_atkdec(&sid->voice[1], data);
-                    break;
-                case M6581_V2_SUSREL:
-                    _m6581_set_susrel(&sid->voice[1], data);
-                    break;
-                case M6581_V3_FREQ_LO:
-                    _m6581_set_freq_lo(&sid->voice[2], data);
-                    break;
-                case M6581_V3_FREQ_HI:
-                    _m6581_set_freq_hi(&sid->voice[2], data);
-                    break;
-                case M6581_V3_PW_LO:
-                    _m6581_set_pw_lo(&sid->voice[2], data);
-                    break;
-                case M6581_V3_PW_HI:
-                    _m6581_set_pw_hi(&sid->voice[2], data);
-                    break;
-                case M6581_V3_CTRL:
-                    _m6581_set_ctrl(&sid->voice[2], data);
-                    break;
-                case M6581_V3_ATKDEC:
-                    _m6581_set_atkdec(&sid->voice[2], data);
-                    break;
-                case M6581_V3_SUSREL:
-                    _m6581_set_susrel(&sid->voice[2], data);
-                    break;
-                case M6581_FC_LO:
-                    _m6581_set_cutoff_lo(&sid->filter, data);
-                    break;
-                case M6581_FC_HI:
-                    _m6581_set_cutoff_hi(&sid->filter, data);
-                    break;
-                case M6581_RES_FILT:
-                    _m6581_set_resfilt(&sid->filter, data);
-                    break;
-                case M6581_MODE_VOL:
-                    _m6581_set_modevol(sid, data);
-                    break;
-            }
-        }
-        sid->pins = pins;
+/* read a register */
+static uint64_t _m6581_read(m6581_t* sid, uint64_t pins) {
+    uint8_t reg = pins & M6581_ADDR_MASK;
+    uint8_t data;
+    switch (reg) {
+        case M6581_POT_X:
+        case M6581_POT_Y:
+            /* FIXME: potentiometers */
+            data = 0;
+            sid->bus_value = 0;
+            break;
+        case M6581_OSC3RAND:
+            /* FIXME */
+            sid->bus_value = 0;
+            data = sid->voice[2].wav_output >> 4;
+            break;
+        case M6581_ENV3:
+            sid->bus_value = 0;
+            data = sid->voice[2].env_cur_level;
+            break;
+        default:
+            data = sid->bus_value;
+            break;
     }
+    M6581_SET_DATA(pins, data);
     return pins;
 }
+
+/* write a register */
+static void _m6581_write(m6581_t* sid, uint64_t pins) {
+    uint8_t reg = pins & M6581_ADDR_MASK;
+    uint8_t data = M6581_GET_DATA(pins);
+    sid->bus_value = data;
+    sid->bus_decay = 0x2000;
+    switch (reg) {
+        case M6581_V1_FREQ_LO:
+            _m6581_set_freq_lo(&sid->voice[0], data);
+            break;
+        case M6581_V1_FREQ_HI:
+            _m6581_set_freq_hi(&sid->voice[0], data);
+            break;
+        case M6581_V1_PW_LO:
+            _m6581_set_pw_lo(&sid->voice[0], data);
+            break;
+        case M6581_V1_PW_HI:
+            _m6581_set_pw_hi(&sid->voice[0], data);
+            break;
+        case M6581_V1_CTRL:
+            _m6581_set_ctrl(&sid->voice[0], data);
+            break;
+        case M6581_V1_ATKDEC:
+            _m6581_set_atkdec(&sid->voice[0], data);
+            break;
+        case M6581_V1_SUSREL:
+            _m6581_set_susrel(&sid->voice[0], data);
+            break;
+        case M6581_V2_FREQ_LO:
+            _m6581_set_freq_lo(&sid->voice[1], data);
+            break;
+        case M6581_V2_FREQ_HI:
+            _m6581_set_freq_hi(&sid->voice[1], data);
+            break;
+        case M6581_V2_PW_LO:
+            _m6581_set_pw_lo(&sid->voice[1], data);
+            break;
+        case M6581_V2_PW_HI:
+            _m6581_set_pw_hi(&sid->voice[1], data);
+            break;
+        case M6581_V2_CTRL:
+            _m6581_set_ctrl(&sid->voice[1], data);
+            break;
+        case M6581_V2_ATKDEC:
+            _m6581_set_atkdec(&sid->voice[1], data);
+            break;
+        case M6581_V2_SUSREL:
+            _m6581_set_susrel(&sid->voice[1], data);
+            break;
+        case M6581_V3_FREQ_LO:
+            _m6581_set_freq_lo(&sid->voice[2], data);
+            break;
+        case M6581_V3_FREQ_HI:
+            _m6581_set_freq_hi(&sid->voice[2], data);
+            break;
+        case M6581_V3_PW_LO:
+            _m6581_set_pw_lo(&sid->voice[2], data);
+            break;
+        case M6581_V3_PW_HI:
+            _m6581_set_pw_hi(&sid->voice[2], data);
+            break;
+        case M6581_V3_CTRL:
+            _m6581_set_ctrl(&sid->voice[2], data);
+            break;
+        case M6581_V3_ATKDEC:
+            _m6581_set_atkdec(&sid->voice[2], data);
+            break;
+        case M6581_V3_SUSREL:
+            _m6581_set_susrel(&sid->voice[2], data);
+            break;
+        case M6581_FC_LO:
+            _m6581_set_cutoff_lo(&sid->filter, data);
+            break;
+        case M6581_FC_HI:
+            _m6581_set_cutoff_hi(&sid->filter, data);
+            break;
+        case M6581_RES_FILT:
+            _m6581_set_resfilt(&sid->filter, data);
+            break;
+        case M6581_MODE_VOL:
+            _m6581_set_modevol(sid, data);
+            break;
+    }
+}
+
+/* the all-in-one tick function */
+uint64_t m6581_tick(m6581_t* sid, uint64_t pins) {
+    CHIPS_ASSERT(sid);
+
+    /* first perform the regular per-tick actions */
+    if (_m6581_tick(sid)) {
+        /* new audio sample is ready */
+        pins |= M6581_SAMPLE;
+    }
+
+    /* register read/write */
+    if (pins & M6581_CS) {
+        if (pins & M6581_RW) {
+            pins = _m6581_read(sid, pins);
+        }
+        else {
+            _m6581_write(sid, pins);
+        }
+    }
+    sid->pins = pins;
+    return pins;
+}
+
 #endif /* CHIPS_IMPL */

--- a/systems/c64.h
+++ b/systems/c64.h
@@ -817,17 +817,17 @@ static uint64_t _c64_tick(c64_t* sys, uint64_t pins) {
         - the VIC-II AEC pin is connected to the CPU AEC pin, currently
         this goes active during a badline, but is not checked
     */
-    vic_pins = m6569_tick(&sys->vic, vic_pins);
-    pins |= (vic_pins & (M6502_IRQ|M6502_RDY|M6510_AEC));
-    /* FIXME: merge with tick */
-    if (vic_pins & M6569_CS) {
-        vic_pins = m6569_iorq(&sys->vic, vic_pins);
-        if (vic_pins & M6569_RW) {
+    {
+        vic_pins = m6569_tick(&sys->vic, vic_pins);
+        pins |= (vic_pins & (M6502_IRQ|M6502_RDY|M6510_AEC));
+        if ((vic_pins & (M6569_CS|M6569_RW)) == (M6569_CS|M6569_RW)) {
             pins = M6502_COPY_DATA(pins, vic_pins);
         }
     }
 
-    /* FIXME */
+    /* remaining CPU IO and memory accesses, those don't fit into the
+       "universal tick model" (yet?)
+    */
     if (cpu_io_access) {
         /* ...the integrated IO port in the M6510 CPU at addresses 0 and 1 */
         pins = m6510_iorq(&sys->cpu, pins);

--- a/systems/c64.h
+++ b/systems/c64.h
@@ -433,10 +433,6 @@ bool c64_is_tape_motor_on(c64_t* sys);
 static uint64_t _c64_tick(c64_t* sys, uint64_t pins);
 static uint8_t _c64_cpu_port_in(void* user_data);
 static void _c64_cpu_port_out(uint8_t data, void* user_data);
-static void _c64_cia1_out(int port_id, uint8_t data, void* user_data);
-static uint8_t _c64_cia1_in(int port_id, void* user_data);
-static void _c64_cia2_out(int port_id, uint8_t data, void* user_data);
-static uint8_t _c64_cia2_in(int port_id, void* user_data);
 static uint16_t _c64_vic_fetch(uint16_t addr, void* user_data);
 static void _c64_update_memory_map(c64_t* sys);
 static void _c64_init_key_map(c64_t* sys);
@@ -477,15 +473,8 @@ void c64_init(c64_t* sys, const c64_desc_t* desc) {
     cpu_desc.m6510_user_data = sys;
     sys->pins = m6502_init(&sys->cpu, &cpu_desc);
 
-    m6526_desc_t cia_desc;
-    _C64_CLEAR(cia_desc);
-    cia_desc.user_data = sys;
-    cia_desc.in_cb = _c64_cia1_in;
-    cia_desc.out_cb = _c64_cia1_out;
-    m6526_init(&sys->cia_1, &cia_desc);
-    cia_desc.in_cb = _c64_cia2_in;
-    cia_desc.out_cb = _c64_cia2_out;
-    m6526_init(&sys->cia_2, &cia_desc);
+    m6526_init(&sys->cia_1);
+    m6526_init(&sys->cia_2);
 
     m6569_desc_t vic_desc;
     _C64_CLEAR(vic_desc);
@@ -688,6 +677,54 @@ static uint64_t _c64_tick(c64_t* sys, uint64_t pins) {
     pins = m6502_tick(&sys->cpu, pins);
     const uint16_t addr = M6502_GET_ADDR(pins);
 
+    /* those pins are set each tick by the CIAs and VIC */
+    pins &= ~(M6502_IRQ|M6502_NMI|M6502_RDY|M6510_AEC);
+
+    /*  address decoding
+
+        When the RDY pin is active (during bad lines), no CPU/chip
+        communication takes place.
+    */
+    bool cpu_io_access = false;
+    bool color_ram_access = false;
+    bool mem_access = false;
+    uint64_t vic_pins = pins & M6502_PIN_MASK;
+    uint64_t cia1_pins = pins & M6502_PIN_MASK;
+    uint64_t cia2_pins = pins & M6502_PIN_MASK;
+    uint64_t sid_pins = pins & M6502_PIN_MASK;
+    if ((pins & (M6502_RDY|M6502_RW)) != (M6502_RDY|M6502_RW)) {
+        if (M6510_CHECK_IO(pins)) {
+            cpu_io_access = true;
+        }
+        else {
+            if (sys->io_mapped && ((addr & 0xF000) == 0xD000)) {
+                if (addr < 0xD400) {
+                    /* VIC-II (D000..D3FF) */
+                    vic_pins |= M6569_CS;
+                }
+                else if (addr < 0xD800) {
+                    /* SID (D400..D7FF) */
+                    sid_pins |= M6581_CS;
+                }
+                else if (addr < 0xDC00) {
+                    /* read or write the special color Static-RAM bank (D800..DBFF) */
+                    color_ram_access = true;
+                }
+                else if (addr < 0xDD00) {
+                    /* CIA-1 (DC00..DCFF) */
+                    cia1_pins |= M6526_CS;
+                }
+                else if (addr < 0xDE00) {
+                    /* CIA-2 (DD00..DDFF) */
+                    cia2_pins |= M6526_CS;
+                }
+            }
+            else {
+                mem_access = true;
+            }
+        }
+    }
+
     /* tick the SID */
     if (m6581_tick(&sys->sid)) {
         /* new audio sample ready */
@@ -699,29 +736,78 @@ static uint64_t _c64_tick(c64_t* sys, uint64_t pins) {
             sys->sample_pos = 0;
         }
     }
-
-    /* cassette port READ pin is connected to CIA-1 FLAG pin */
-    uint64_t cia1_pins = pins;
-    if (sys->cas_port & C64_CASPORT_READ) {
-        cia1_pins |= M6526_FLAG;
+    /* FIXME: merge with tick */
+    if (sid_pins & M6581_CS) {
+        sid_pins = m6581_iorq(&sys->sid, sid_pins);
+        if (sid_pins & M6581_RW) {
+            pins = M6502_COPY_DATA(pins, sid_pins);
+        }
     }
 
-    /* tick the CIAs:
-        - CIA-1 gets the FLAG pin from the datasette
-        - the CIA-1 IRQ pin is connected to the CPU IRQ pin
-        - the CIA-2 IRQ pin is connected to the CPU NMI pin
+    /* tick CIA-1:
+
+        In Port A:
+            joystick 2 input
+        In Port B:
+            combined keyboard matrix columns and joystick 1
+        Cas Port Read => Flag pin
+
+        Out Port A:
+            write keyboard matrix lines
+
+        IRQ pin is connected to the CPU IRQ pin
     */
-    if (m6526_tick(&sys->cia_1, cia1_pins & ~M6502_IRQ) & M6502_IRQ) {
-        pins |= M6502_IRQ;
+    {
+        /* cassette port READ pin is connected to CIA-1 FLAG pin */
+        /* FIXME: precompute merged joystick mask like in vic20.h */
+        const uint8_t pa = ~(sys->kbd_joy2_mask|sys->joy_joy2_mask);
+        const uint8_t pb = ~(kbd_scan_columns(&sys->kbd) | sys->kbd_joy1_mask | sys->joy_joy1_mask);
+        M6526_SET_PAB(pins, pa, pb);
+        if (sys->cas_port & C64_CASPORT_READ) {
+            cia1_pins |= M6526_FLAG;
+        }
+        cia1_pins = m6526_tick(&sys->cia_1, cia1_pins);
+        const uint8_t kbd_lines = ~M6526_GET_PA(cia1_pins);
+        kbd_set_active_lines(&sys->kbd, kbd_lines);
+        if (cia1_pins & M6502_IRQ) {
+            pins |= M6502_IRQ;
+        }
+        if ((cia1_pins & (M6526_CS|M6526_RW)) == (M6526_CS|M6526_RW)) {
+            pins = M6502_COPY_DATA(pins, cia1_pins);
+        }
     }
-    else {
-        pins &= ~M6502_IRQ;
-    }
-    if (m6526_tick(&sys->cia_2, pins & ~M6502_IRQ) & M6502_IRQ) {
-        pins |= M6502_NMI;
-    }
-    else {
-        pins &= ~M6502_NMI;
+
+    /* tick CIA-2
+        In Port A:
+            bits 0..5: output (see cia2_out)
+            bits 6..7: serial bus input, not implemented
+        In Port B:
+            RS232 / user functionality (not implemented)
+
+        Out Port A:
+            bits 0..1: VIC-II bank select:
+                00: bank 3 C000..FFFF
+                01: bank 2 8000..BFFF
+                10: bank 1 4000..7FFF
+                11: bank 0 0000..3FFF
+            bit 2: RS-232 TXD Outout (not implemented)
+            bit 3..5: serial bus output (not implemented)
+            bit 6..7: input (see cia2_in)
+        Out Port B:
+            RS232 / user functionality (not implemented)
+
+        CIA-2 IRQ pin connected to CPU NMI pin
+    */
+    {
+        M6526_SET_PAB(cia2_pins, 0xFF, 0xFF);
+        cia2_pins = m6526_tick(&sys->cia_2, cia2_pins);
+        sys->vic_bank_select = ((~M6526_GET_PA(cia2_pins))&3)<<14;
+        if (cia2_pins & M6502_IRQ) {
+            pins |= M6502_NMI;
+        }
+        if ((cia2_pins & (M6526_CS|M6526_RW)) == (M6526_CS|M6526_RW)) {
+            pins = M6502_COPY_DATA(pins, cia2_pins);
+        }
     }
 
     /* tick the VIC-II display chip:
@@ -732,72 +818,37 @@ static uint64_t _c64_tick(c64_t* sys, uint64_t pins) {
         - the VIC-II AEC pin is connected to the CPU AEC pin, currently
         this goes active during a badline, but is not checked
     */
-    pins = m6569_tick(&sys->vic, pins);
-
-    /* Special handling when the VIC-II asks the CPU to stop during a
-        'badline' via the BA=>RDY pin. If the RDY pin is active, the
-        CPU will 'loop' on the tick callback during the next READ access
-        until the RDY pin goes inactive. The tick callback must make sure
-        that only a single READ access happens during the entire RDY period.
-        Currently this happens on the very last tick when RDY goes from
-        active to inactive (I haven't found definitive documentation if
-        this is the right behaviour, but it made the Boulderdash fast loader work).
-    */
-    if ((pins & (M6502_RDY|M6502_RW)) == (M6502_RDY|M6502_RW)) {
-        return pins;
+    vic_pins = m6569_tick(&sys->vic, vic_pins);
+    pins |= (vic_pins & (M6502_IRQ|M6502_RDY|M6510_AEC));
+    /* FIXME: merge with tick */
+    if (vic_pins & M6569_CS) {
+        vic_pins = m6569_iorq(&sys->vic, vic_pins);
+        if (vic_pins & M6569_RW) {
+            pins = M6502_COPY_DATA(pins, vic_pins);
+        }
     }
 
-    /* handle IO requests */
-    if (M6510_CHECK_IO(pins)) {
+    /* FIXME */
+    if (cpu_io_access) {
         /* ...the integrated IO port in the M6510 CPU at addresses 0 and 1 */
         pins = m6510_iorq(&sys->cpu, pins);
     }
-    else {
-        /* ...the memory-mapped IO area from 0xD000 to 0xDFFF */
-        if (sys->io_mapped && ((addr & 0xF000) == 0xD000)) {
-            if (addr < 0xD400) {
-                /* VIC-II (D000..D3FF) */
-                uint64_t vic_pins = (pins & M6502_PIN_MASK)|M6569_CS;
-                pins = m6569_iorq(&sys->vic, vic_pins) & M6502_PIN_MASK;
-            }
-            else if (addr < 0xD800) {
-                /* SID (D400..D7FF) */
-                uint64_t sid_pins = (pins & M6502_PIN_MASK)|M6581_CS;
-                pins = m6581_iorq(&sys->sid, sid_pins) & M6502_PIN_MASK;
-            }
-            else if (addr < 0xDC00) {
-                /* read or write the special color Static-RAM bank (D800..DBFF) */
-                if (pins & M6502_RW) {
-                    M6502_SET_DATA(pins, sys->color_ram[addr & 0x03FF]);
-                }
-                else {
-                    sys->color_ram[addr & 0x03FF] = M6502_GET_DATA(pins);
-                }
-            }
-            else if (addr < 0xDD00) {
-                /* CIA-1 (DC00..DCFF) */
-                uint64_t cia_pins = (pins & M6502_PIN_MASK)|M6526_CS;
-                pins = m6526_iorq(&sys->cia_1, cia_pins) & M6502_PIN_MASK;
-            }
-            else if (addr < 0xDE00) {
-                /* CIA-2 (DD00..DDFF) */
-                uint64_t cia_pins = (pins & M6502_PIN_MASK)|M6526_CS;
-                pins = m6526_iorq(&sys->cia_2, cia_pins) & M6502_PIN_MASK;
-            }
-            else {
-                /* FIXME: expansion system (not implemented) */
-            }
+    else if (color_ram_access) {
+        if (pins & M6502_RW) {
+            M6502_SET_DATA(pins, sys->color_ram[addr & 0x03FF]);
         }
         else {
-            /* a regular memory access */
-            if (pins & M6502_RW) {
-                /* memory read */
-                M6502_SET_DATA(pins, mem_rd(&sys->mem_cpu, addr));
-            }
-            else {
-                /* memory write */
-                mem_wr(&sys->mem_cpu, addr, M6502_GET_DATA(pins));
-            }
+            sys->color_ram[addr & 0x03FF] = M6502_GET_DATA(pins);
+        }
+    }
+    else if (mem_access) {
+        if (pins & M6502_RW) {
+            /* memory read */
+            M6502_SET_DATA(pins, mem_rd(&sys->mem_cpu, addr));
+        }
+        else {
+            /* memory write */
+            mem_wr(&sys->mem_cpu, addr, M6502_GET_DATA(pins));
         }
     }
     return pins;
@@ -841,75 +892,6 @@ static void _c64_cpu_port_out(uint8_t data, void* user_data) {
     if (need_mem_update) {
         _c64_update_memory_map(sys);
     }
-}
-
-static void _c64_cia1_out(int port_id, uint8_t data, void* user_data) {
-    c64_t* sys = (c64_t*) user_data;
-    /*
-        Write CIA-1 ports:
-
-        port A:
-            write keyboard matrix lines
-        port B:
-            ---
-    */
-    if (port_id == M6526_PORT_A) {
-        kbd_set_active_lines(&sys->kbd, ~data);
-    }
-}
-
-static uint8_t _c64_cia1_in(int port_id, void* user_data) {
-    c64_t* sys = (c64_t*) user_data;
-    /*
-        Read CIA-1 ports:
-
-        Port A:
-            joystick 2 input
-        Port B:
-            combined keyboard matrix columns and joystick 1
-    */
-    if (port_id == M6526_PORT_A) {
-        return ~(sys->kbd_joy2_mask | sys->joy_joy2_mask);
-    }
-    else {
-        /* read keyboard matrix columns */
-        return ~(kbd_scan_columns(&sys->kbd) | sys->kbd_joy1_mask | sys->joy_joy1_mask);
-    }
-}
-
-static void _c64_cia2_out(int port_id, uint8_t data, void* user_data) {
-    c64_t* sys = (c64_t*) user_data;
-    /*
-        Write CIA-2 ports:
-
-        Port A:
-            bits 0..1: VIC-II bank select:
-                00: bank 3 C000..FFFF
-                01: bank 2 8000..BFFF
-                10: bank 1 4000..7FFF
-                11: bank 0 0000..3FFF
-            bit 2: RS-232 TXD Outout (not implemented)
-            bit 3..5: serial bus output (not implemented)
-            bit 6..7: input (see cia2_in)
-        Port B:
-            RS232 / user functionality (not implemented)
-    */
-    if (port_id == M6526_PORT_A) {
-        sys->vic_bank_select = ((~data)&3)<<14;
-    }
-}
-
-static uint8_t _c64_cia2_in(int port_id, void* user_data) {
-    /*
-        Read CIA-2 ports:
-
-        Port A:
-            bits 0..5: output (see cia2_out)
-            bits 6..7: serial bus input, not implemented
-        Port B:
-            RS232 / user functionality (not implemented)
-    */
-    return ~0;
 }
 
 static uint16_t _c64_vic_fetch(uint16_t addr, void* user_data) {

--- a/systems/c64.h
+++ b/systems/c64.h
@@ -758,7 +758,6 @@ static uint64_t _c64_tick(c64_t* sys, uint64_t pins) {
     */
     {
         /* cassette port READ pin is connected to CIA-1 FLAG pin */
-        /* FIXME: precompute merged joystick mask like in vic20.h */
         const uint8_t pa = ~(sys->kbd_joy2_mask|sys->joy_joy2_mask);
         const uint8_t pb = ~(kbd_scan_columns(&sys->kbd) | sys->kbd_joy1_mask | sys->joy_joy1_mask);
         M6526_SET_PAB(cia1_pins, pa, pb);

--- a/systems/c64.h
+++ b/systems/c64.h
@@ -762,7 +762,7 @@ static uint64_t _c64_tick(c64_t* sys, uint64_t pins) {
         /* FIXME: precompute merged joystick mask like in vic20.h */
         const uint8_t pa = ~(sys->kbd_joy2_mask|sys->joy_joy2_mask);
         const uint8_t pb = ~(kbd_scan_columns(&sys->kbd) | sys->kbd_joy1_mask | sys->joy_joy1_mask);
-        M6526_SET_PAB(pins, pa, pb);
+        M6526_SET_PAB(cia1_pins, pa, pb);
         if (sys->cas_port & C64_CASPORT_READ) {
             cia1_pins |= M6526_FLAG;
         }

--- a/ui/ui_m6526.h
+++ b/ui/ui_m6526.h
@@ -132,12 +132,12 @@ static void _ui_m6526_draw_state(ui_m6526_t* win) {
     ImGui::Text("DDR"); ImGui::NextColumn();
     ui_util_b8("", cia->pa.ddr); ImGui::NextColumn();
     ui_util_b8("", cia->pb.ddr); ImGui::NextColumn();
-    ImGui::Text("Input"); ImGui::NextColumn();
-    ui_util_b8("", cia->pa.inpr); ImGui::NextColumn();
-    ui_util_b8("", cia->pb.inpr); ImGui::NextColumn();
-    ImGui::Text("Output"); ImGui::NextColumn();
-    ui_util_b8("", cia->pa.outr); ImGui::NextColumn();
-    ui_util_b8("", cia->pb.outr); ImGui::NextColumn();
+    ImGui::Text("Reg"); ImGui::NextColumn();
+    ui_util_b8("", cia->pa.reg); ImGui::NextColumn();
+    ui_util_b8("", cia->pb.reg); ImGui::NextColumn();
+    ImGui::Text("Inp"); ImGui::NextColumn();
+    ui_util_b8("", cia->pa.inp); ImGui::NextColumn();
+    ui_util_b8("", cia->pb.inp); ImGui::NextColumn();
     ImGui::Text("Pins"); ImGui::NextColumn();
     ui_util_b8("", cia->pa.pins); ImGui::NextColumn();
     ui_util_b8("", cia->pb.pins); ImGui::NextColumn();

--- a/ui/ui_m6526.h
+++ b/ui/ui_m6526.h
@@ -132,19 +132,16 @@ static void _ui_m6526_draw_state(ui_m6526_t* win) {
     ImGui::Text("DDR"); ImGui::NextColumn();
     ui_util_b8("", cia->pa.ddr); ImGui::NextColumn();
     ui_util_b8("", cia->pb.ddr); ImGui::NextColumn();
-    ImGui::Text("Register"); ImGui::NextColumn();
-    ui_util_b8("", cia->pa.reg); ImGui::NextColumn();
-    ui_util_b8("", cia->pb.reg); ImGui::NextColumn();
     ImGui::Text("Input"); ImGui::NextColumn();
-    ui_util_b8("", cia->pa.inp); ImGui::NextColumn();
-    ui_util_b8("", cia->pb.inp); ImGui::NextColumn();
+    ui_util_b8("", cia->pa.inpr); ImGui::NextColumn();
+    ui_util_b8("", cia->pb.inpr); ImGui::NextColumn();
     ImGui::Text("Output"); ImGui::NextColumn();
-    ui_util_b8("", cia->pa.out); ImGui::NextColumn();
-    ui_util_b8("", cia->pb.out); ImGui::NextColumn();
+    ui_util_b8("", cia->pa.outr); ImGui::NextColumn();
+    ui_util_b8("", cia->pb.outr); ImGui::NextColumn();
     ImGui::Text("Pins"); ImGui::NextColumn();
-    ui_util_b8("", cia->pa.port); ImGui::NextColumn();
-    ui_util_b8("", cia->pb.port); ImGui::NextColumn();
-    
+    ui_util_b8("", cia->pa.pins); ImGui::NextColumn();
+    ui_util_b8("", cia->pb.pins); ImGui::NextColumn();
+
     /* timers */
     ImGui::Separator();
     ImGui::NextColumn();


### PR DESCRIPTION
Merged the *_iorq() functions into the *_tick() functions in all C64 chip emus:

- m6569.h
- m6581.h
- m6526.h

...and the accompanying changes in the c64 emulation.