### PR TITLE
i8255.h, mc6847.h: merge iorq() into tick() function

### DIFF
--- a/chips/i8255.h
+++ b/chips/i8255.h
@@ -125,7 +125,10 @@ extern "C" {
 #define I8255_PB7       (1ULL<<63)
 #define I8255_PB_PINS   (I8255_PB0|I8255_PB1|I8255_PB2|I8255_PB3|I8255_PB4|I8255_PB5|I8255_PB6|I8255_PB7)
 
-/* port C pins, NOTE: these overlap with address bus pins A8..A15, because there's no room left */
+/* port C pins, NOTE: these overlap with address bus pins A8..A15!
+   don't forget to clear upper 8 address bus pins when reusing the
+   CPU pin mask for the i8255!
+*/
 #define I8255_PC0       (1ULL<<8)
 #define I8255_PC1       (1ULL<<9)
 #define I8255_PC2       (1ULL<<10)
@@ -227,7 +230,7 @@ typedef struct {
 #define I8255_GET_PC(p) ((uint8_t)(p>>8))
 /* set port pins into pin mask */
 #define I8255_SET_PA(p,a) {p=(p&0xFF00FFFFFFFFFFFF)|((a&0xFFUL)<<48);}
-#define I8255_SET_PB(p,b) {p=(p&0x00FFFFFFFFFFFFFF)|((b&0xFFUL)<<58);}
+#define I8255_SET_PB(p,b) {p=(p&0x00FFFFFFFFFFFFFF)|((b&0xFFUL)<<56);}
 #define I8255_SET_PCHI(p,c) {p=(p&0xFFFFFFFFFFFF0FFF)|((c&0xF0UL)<<8);}
 #define I8255_SET_PCLO(p,c) {p=(p&0xFFFFFFFFFFFFF0FF)|((c&0x0FUL)<<8);}
 

--- a/chips/i8255.h
+++ b/chips/i8255.h
@@ -231,6 +231,7 @@ typedef struct {
 /* set port pins into pin mask */
 #define I8255_SET_PA(p,a) {p=(p&0xFF00FFFFFFFFFFFF)|((a&0xFFUL)<<48);}
 #define I8255_SET_PB(p,b) {p=(p&0x00FFFFFFFFFFFFFF)|((b&0xFFUL)<<56);}
+#define I8255_SET_PC(p,c) {p=(p&0xFFFFFFFFFFFF00FF)|((c&0xFFUL)<<8);}
 #define I8255_SET_PCHI(p,c) {p=(p&0xFFFFFFFFFFFF0FFF)|((c&0xF0UL)<<8);}
 #define I8255_SET_PCLO(p,c) {p=(p&0xFFFFFFFFFFFFF0FF)|((c&0x0FUL)<<8);}
 

--- a/chips/i8255.h
+++ b/chips/i8255.h
@@ -31,6 +31,7 @@
         - mode 1 (strobed input/output)
         - mode 2 (bi-directional bus)
         - interrupts
+        - input latches
     
     FIXME: documentation
 
@@ -81,66 +82,61 @@ extern "C" {
     Invoke those operations via to i8255_iorq() function.
 */
 
+/* control pins shared with Z80 */
+#define I8255_RD    (1ULL<<27)      /* read from PPI, shared with Z80_RD! */
+#define I8255_WR    (1ULL<<28)      /* write to PPI, shared with Z80_WR! */
+
 /* i8255 control pins */
-#define I8255_CS    (1ULL<<40)     /* chip-select, i8255 responds to RW/WR when this is active */
-#define I8255_RD    (1ULL<<41)     /* read from PPI */
-#define I8255_WR    (1ULL<<42)     /* write to PPI */
-#define I8255_A0    (1ULL<<43)     /* address bit 0 */
-#define I8255_A1    (1ULL<<44)     /* address bit 1 */
+#define I8255_CS    (1ULL<<40)      /* chip-select, i8255 responds to RW/WR when this is active */
+
+/* register addressing pins same as address bus pins A0 and A1 */
+#define I8255_A0    (1ULL<<0)       /* address bit 0 */
+#define I8255_A1    (1ULL<<1)       /* address bit 1 */
 
 /* data bus pins shared with CPU */
-#define I8255_D0  (1ULL<<16)
-#define I8255_D1  (1ULL<<17)
-#define I8255_D2  (1ULL<<18)
-#define I8255_D3  (1ULL<<19)
-#define I8255_D4  (1ULL<<20)
-#define I8255_D5  (1ULL<<21)
-#define I8255_D6  (1ULL<<22)
-#define I8255_D7  (1ULL<<23)
+#define I8255_D0    (1ULL<<16)
+#define I8255_D1    (1ULL<<17)
+#define I8255_D2    (1ULL<<18)
+#define I8255_D3    (1ULL<<19)
+#define I8255_D4    (1ULL<<20)
+#define I8255_D5    (1ULL<<21)
+#define I8255_D6    (1ULL<<22)
+#define I8255_D7    (1ULL<<23)
 
-/* NOTE the Port I/O pins are only visible in the 'pins' member,
-   they are not accepted as input, and are not returned as output
-   of the i8255_iorq() function! Usually the pins member
-   is used for debug visualization, since the port I/O is handled
-   through callback functions.
-*/
-#define I8255_PA0       (1ULL<<0)
-#define I8255_PA1       (1ULL<<1)
-#define I8255_PA2       (1ULL<<2)
-#define I8255_PA3       (1ULL<<3)
-#define I8255_PA4       (1ULL<<4)
-#define I8255_PA5       (1ULL<<5)
-#define I8255_PA6       (1ULL<<6)
-#define I8255_PA7       (1ULL<<7)
+/* port A pins */
+#define I8255_PA0       (1ULL<<48)
+#define I8255_PA1       (1ULL<<49)
+#define I8255_PA2       (1ULL<<50)
+#define I8255_PA3       (1ULL<<51)
+#define I8255_PA4       (1ULL<<52)
+#define I8255_PA5       (1ULL<<53)
+#define I8255_PA6       (1ULL<<54)
+#define I8255_PA7       (1ULL<<55)
+#define I8255_PA_PINS   (I8255_PA0|I8255_PA1|I8255_PA2|I8255_PA3|I8255_PA4|I8255_PA5|I8255_PA6|I8255_PA7)
 
-#define I8255_PB0       (1ULL<<8)
-#define I8255_PB1       (1ULL<<9)
-#define I8255_PB2       (1ULL<<10)
-#define I8255_PB3       (1ULL<<11)
-#define I8255_PB4       (1ULL<<12)
-#define I8255_PB5       (1ULL<<13)
-#define I8255_PB6       (1ULL<<14)
-#define I8255_PB7       (1ULL<<15)
+/* port B pins */
+#define I8255_PB0       (1ULL<<56)
+#define I8255_PB1       (1ULL<<57)
+#define I8255_PB2       (1ULL<<58)
+#define I8255_PB3       (1ULL<<59)
+#define I8255_PB4       (1ULL<<60)
+#define I8255_PB5       (1ULL<<61)
+#define I8255_PB6       (1ULL<<62)
+#define I8255_PB7       (1ULL<<63)
+#define I8255_PB_PINS   (I8255_PB0|I8255_PB1|I8255_PB2|I8255_PB3|I8255_PB4|I8255_PB5|I8255_PB6|I8255_PB7)
 
-#define I8255_PC0       (1ULL<<48)
-#define I8255_PC1       (1ULL<<49)
-#define I8255_PC2       (1ULL<<50)
-#define I8255_PC3       (1ULL<<51)
-#define I8255_PC4       (1ULL<<52)
-#define I8255_PC5       (1ULL<<53)
-#define I8255_PC6       (1ULL<<54)
-#define I8255_PC7       (1ULL<<55)
+/* port C pins, NOTE: these overlap with address bus pins A8..A15, because there's no room left */
+#define I8255_PC0       (1ULL<<8)
+#define I8255_PC1       (1ULL<<9)
+#define I8255_PC2       (1ULL<<10)
+#define I8255_PC3       (1ULL<<11)
+#define I8255_PC4       (1ULL<<12)
+#define I8255_PC5       (1ULL<<13)
+#define I8255_PC6       (1ULL<<14)
+#define I8255_PC7       (1ULL<<15)
+#define I8255_PC_PINS   (I8255_PC0|I8255_PC1|I8255_PC2|I8255_PC3|I8255_PC4|I8255_PC5|I8255_PC6|I8255_PC7)
 
-#define I8255_PA_BITS   (0x00000000000000FFULL)
-#define I8255_PB_BITS   (0x000000000000FF00ULL)
-#define I8255_PC_BITS   (0x00FF000000000000ULL)
-#define I8255_PORT_BITS (I8255_PA_BITS|I8255_PB_BITS|I8255_PC_BITS)
-
-/* port names */
-#define I8255_PORT_A    (0)
-#define I8255_PORT_B    (1)
-#define I8255_PORT_C    (2)
-#define I8255_NUM_PORTS (3)
+#define I8255_PORT_PINS (I8255_PA_PINS|I8255_PB_PINS|I8255_PC_PINS)
 
 /*
     Control word bits
@@ -169,9 +165,9 @@ extern "C" {
 */
 
 /* mode select or interrupt control */
-#define I8255_CTRL_CONTROL               (1<<7)
-#define I8255_CTRL_CONTROL_MODE          (1<<7)
-#define I8255_CTRL_CONTROL_BIT           (0)
+#define I8255_CTRL_CONTROL          (1<<7)
+#define I8255_CTRL_CONTROL_MODE     (1<<7)
+#define I8255_CTRL_CONTROL_BIT      (0)
 
 /* port C (lower) input/output select */
 #define I8255_CTRL_CLO              (1<<0)
@@ -209,75 +205,38 @@ extern "C" {
 #define I8255_CTRL_BIT_SET          (1<<0)
 #define I8255_CTRL_BIT_RESET        (0)
 
-/* callbacks for input/output on ports */
-typedef uint8_t (*i8255_in_t)(int port_id, void* user_data);
-typedef uint64_t (*i8255_out_t)(int port_id, uint64_t pins, uint8_t data, void* user_data);
-
-/* initialization parameters */
+/* i8255 port state */
 typedef struct {
-    i8255_in_t in_cb;       /* port-input callback */
-    i8255_out_t out_cb;     /* port-output callback */
-    void* user_data;        /* optional user-data for callbacks */
-} i8255_desc_t;
+    uint8_t outp;   /* output latch (FIXME: input latch) */
+} i8255_port_t;
 
 /* i8255 state */
 typedef struct {
-    /* port output latches */
-    uint8_t output[I8255_NUM_PORTS];
-    /* control word */
+    i8255_port_t pa, pb, pc;
     uint8_t control;
-    /* last input or output value on port */
-    uint8_t port[I8255_NUM_PORTS];
-    /* last pin state in i8255_iorq(), with PA/PB/PC pins merged in */
     uint64_t pins;
-    /* port-input callback */
-    i8255_in_t in_cb;
-    /* port-output callback */
-    i8255_out_t out_cb;
-    /* optional user-data for callbacks */
-    void* user_data;
 } i8255_t;
 
 /* extract 8-bit data bus from 64-bit pins */
 #define I8255_GET_DATA(p) ((uint8_t)(p>>16))
 /* merge 8-bit data bus value into 64-bit pins */
 #define I8255_SET_DATA(p,d) {p=((p&~0xFF0000)|((d&0xFF)<<16));}
+/* extract port pins */
+#define I8255_GET_PA(p) ((uint8_t)(p>>48))
+#define I8255_GET_PB(p) ((uint8_t)(p>>56))
+#define I8255_GET_PC(p) ((uint8_t)(p>>8))
+/* set port pins into pin mask */
+#define I8255_SET_PA(p,a) {p=(p&0xFF00FFFFFFFFFFFF)|((a&0xFFUL)<<48);}
+#define I8255_SET_PB(p,b) {p=(p&0x00FFFFFFFFFFFFFF)|((b&0xFFUL)<<58);}
+#define I8255_SET_PCHI(p,c) {p=(p&0xFFFFFFFFFFFF0FFF)|((c&0xF0UL)<<8);}
+#define I8255_SET_PCLO(p,c) {p=(p&0xFFFFFFFFFFFFF0FF)|((c&0x0FUL)<<8);}
 
-/*
-    i8255_init
-
-    This initializes a new i8255 instance, which will clear
-    the i8255_t struct and put the chip into its reset state.
-
-    ppi     -- pointer to a i8255_t instance
-    in_cb   -- function to be called when input on a port is needed
-    out_cb  -- function to be called when output on a port is performed
-*/
-void i8255_init(i8255_t* ppi, const i8255_desc_t* desc);
-
-/*
-    i8255_reset
-
-    Puts the i8255 into the reset state. Clears the control word register
-    and puts all ports into input mode.
-*/
+/* initialize a new i8255_t instance */
+void i8255_init(i8255_t* ppi);
+/* reset i8255_t instance */
 void i8255_reset(i8255_t* ppi);
-
-/*
-    i8255_iorq
-
-    Performs a read or write operation on the PPI. The pins 
-    CS|RD|WR define whether this is a read or write operation,
-    the address pins A0|A1 define the port number, or
-    whether the control word is affected. If this is a
-    write operation, the data bus pins must contain the value
-    to be written.
-
-    Calling this function may cause invocation of the in/out
-    callback function, and the data bus pins may be modified
-    (if this is a read operation).
-*/
-uint64_t i8255_iorq(i8255_t* ppi, uint64_t pins);
+/* tick i8255_t instance */
+uint64_t i8255_tick(i8255_t* ppi, uint64_t pins);
 
 #ifdef __cplusplus
 } /* extern "C" */
@@ -291,12 +250,9 @@ uint64_t i8255_iorq(i8255_t* ppi, uint64_t pins);
     #define CHIPS_ASSERT(c) assert(c)
 #endif
 
-void i8255_init(i8255_t* ppi, const i8255_desc_t* desc) {
-    CHIPS_ASSERT(ppi && desc && desc->in_cb && desc->out_cb);
+void i8255_init(i8255_t* ppi) {
+    CHIPS_ASSERT(ppi);
     memset(ppi, 0, sizeof(*ppi));
-    ppi->in_cb = desc->in_cb;
-    ppi->out_cb = desc->out_cb;
-    ppi->user_data = desc->user_data;
     i8255_reset(ppi);
 }
 
@@ -304,203 +260,117 @@ void i8255_reset(i8255_t* ppi) {
     CHIPS_ASSERT(ppi);
     /* set all ports to input */
     ppi->control = I8255_CTRL_CONTROL_MODE|
-                    I8255_CTRL_CLO_INPUT|
-                    I8255_CTRL_CHI_INPUT|
-                    I8255_CTRL_B_INPUT|
-                    I8255_CTRL_A_INPUT;
-    for (int i = 0; i < I8255_NUM_PORTS; i++) {
-        ppi->output[i] = 0;
-        ppi->port[i] = 0xFF;
-    }
-}
-
-/* handle output on port A or B */
-static inline uint64_t _i8255_out_a(i8255_t* ppi, uint64_t pins, uint8_t data) {
-    ppi->output[I8255_PORT_A] = data;
-    ppi->port[I8255_PORT_A] = data;
-    return ppi->out_cb(I8255_PORT_A, pins, data, ppi->user_data);
-}
-
-static inline uint64_t _i8255_out_b(i8255_t* ppi, uint64_t pins, uint8_t data) {
-    ppi->output[I8255_PORT_B] = data;
-    ppi->port[I8255_PORT_B] = data;
-    return ppi->out_cb(I8255_PORT_B, pins, data, ppi->user_data);
-}
-
-/* handle output on port C (which is split in upper/lower half) */
-static inline uint64_t _i8255_out_c(i8255_t* ppi, uint64_t pins) {
-    uint8_t mask = 0, data = 0;
-    if ((ppi->control & I8255_CTRL_CHI) == I8255_CTRL_CHI_OUTPUT) {
-        mask |= 0xF0;
-    }
-    else {
-        data |= 0xF0;   /* in input mode, return all bits as set */
-    }
-    if ((ppi->control & I8255_CTRL_CLO) == I8255_CTRL_CLO_OUTPUT) {
-        mask |= 0x0F;
-    }
-    else {
-        data |= 0x0F;
-    }
-    data |= ppi->output[I8255_PORT_C] & mask;
-    ppi->port[I8255_PORT_C] = (ppi->port[I8255_PORT_C] & ~mask) | (data & mask);
-    pins = ppi->out_cb(I8255_PORT_C, pins, data, ppi->user_data);
-    return pins;
-}
-
-/* handle input from port A or B */
-static inline uint8_t _i8255_in_a(i8255_t* ppi) {
-    uint8_t data;
-    if ((ppi->control & I8255_CTRL_A) == I8255_CTRL_A_OUTPUT) {
-        data = ppi->output[I8255_PORT_A];
-    }
-    else {
-        data = ppi->in_cb(I8255_PORT_A, ppi->user_data);
-    }
-    ppi->port[I8255_PORT_A] = data;
-    return data;
-}
-
-static inline uint8_t _i8255_in_b(i8255_t* ppi) {
-    uint8_t data;
-    if ((ppi->control & I8255_CTRL_B) == I8255_CTRL_B_OUTPUT) {
-        data = ppi->output[I8255_PORT_B];
-    }
-    else {
-        data = ppi->in_cb(I8255_PORT_B, ppi->user_data);
-    }
-    ppi->port[I8255_PORT_B] = data;
-    return data;
-}
-
-/* handle input on port C (which is split in upper and lower half) */
-static inline uint8_t _i8255_in_c(i8255_t* ppi) {
-    uint8_t mask = 0, data = 0;
-    if ((ppi->control & I8255_CTRL_CHI) == I8255_CTRL_CHI_OUTPUT) {
-        /* read data from output latch */
-        data |= ppi->output[I8255_PORT_C] & 0xF0;
-    }
-    else {
-        /* read data from port */
-        mask |= 0xF0;
-    }
-    if ((ppi->control & I8255_CTRL_CLO) == I8255_CTRL_CLO_OUTPUT) {
-        /* read data from output latch */
-        data |= ppi->output[I8255_PORT_C] & 0x0F;
-    }
-    else {
-        /* read data from port */
-        mask |= 0x0F;
-    }
-    if (0 != mask) {
-        data |= ppi->in_cb(I8255_PORT_C, ppi->user_data);
-    }
-    ppi->port[I8255_PORT_C] = (ppi->port[I8255_PORT_C] & ~mask) | (data & mask);
-    return data;
-}
-
-/* set new control word */
-static uint64_t _i8255_select_mode(i8255_t* ppi, uint64_t pins, uint8_t data) {
-    ppi->control = data;
-    for (int i = 0; i < I8255_NUM_PORTS; i++) {
-        ppi->output[i] = 0;
-        ppi->port[i] = 0;
-    }
-    if ((ppi->control & I8255_CTRL_A) == I8255_CTRL_A_OUTPUT) {
-        pins = _i8255_out_a(ppi, pins, 0);
-    }
-    else {
-        pins = _i8255_out_a(ppi, pins, 0xFF);
-    }
-    if ((ppi->control & I8255_CTRL_B) == I8255_CTRL_B_OUTPUT) {
-        pins = _i8255_out_b(ppi, pins, 0);
-    }
-    else {
-        pins = _i8255_out_b(ppi, pins, 0xFF);
-    }
-    pins = _i8255_out_c(ppi, pins);
-    return pins;
+                   I8255_CTRL_CLO_INPUT|
+                   I8255_CTRL_CHI_INPUT|
+                   I8255_CTRL_B_INPUT|
+                   I8255_CTRL_A_INPUT;
+    ppi->pa.outp = 0;
 }
 
 /* write a value to the PPI */
-static uint64_t _i8255_write(i8255_t* ppi, uint64_t pins, uint8_t data) {
+static void _i8255_write(i8255_t* ppi, uint64_t pins) {
+    uint8_t data = I8255_GET_DATA(pins);
     switch (pins & (I8255_A0|I8255_A1)) {
         case 0: /* write to port A */
             if ((ppi->control & I8255_CTRL_A) == I8255_CTRL_A_OUTPUT) {
-                pins = _i8255_out_a(ppi, pins, data);
+                ppi->pa.outp = data;
             }
             break;
-        case I8255_A0: /* write to port B */
+        case 1: /* write to port B */
             if ((ppi->control & I8255_CTRL_B) == I8255_CTRL_B_OUTPUT) {
-                pins = _i8255_out_b(ppi, pins, data);
+                ppi->pb.outp = data;
             }
             break;
-        case I8255_A1: /* write to port C */
-            ppi->output[I8255_PORT_C] = data;
-            pins = _i8255_out_c(ppi, pins);
+        case 2: /* write to port C */
+            ppi->pc.outp = data;
             break;
-        case (I8255_A0|I8255_A1): /* control operation*/
+        case 3: /* control operation*/
             if ((data & I8255_CTRL_CONTROL) == I8255_CTRL_CONTROL_MODE) {
                 /* set port mode */
-                pins = _i8255_select_mode(ppi, pins, data);
+                ppi->control = data;
+                ppi->pa.outp = 0;
+                ppi->pb.outp = 0;
+                ppi->pc.outp = 0;
             }
             else {
                 /* set/clear single bit in port C */
                 const uint8_t mask = 1<<((data>>1)&7);
                 if ((data & I8255_CTRL_BIT) == I8255_CTRL_BIT_SET) {
-                    /* set bit */
-                    ppi->output[I8255_PORT_C] |= mask;
+                    ppi->pc.outp |= mask;
                 }
                 else {
-                    /* clear bit */
-                    ppi->output[I8255_PORT_C] &= ~mask;
+                    ppi->pc.outp &= ~mask;
                 }
-                /* FIXME: interrupts, buffer full flags */
-                pins = _i8255_out_c(ppi, pins);
             }
             break;
+    }
+}
+
+/* read a value from the PPI */
+static uint64_t _i8255_read(i8255_t* ppi, uint64_t pins) {
+    uint8_t data = 0xFF;
+    switch (pins & (I8255_A0|I8255_A1)) {
+        case 0: /* read from port A */
+            if ((ppi->control & I8255_CTRL_A) == I8255_CTRL_A_OUTPUT) {
+                data = ppi->pa.outp;
+            }
+            else {
+                data = I8255_GET_PA(pins);
+            }
+            break;
+        case 1: /* read from port B */
+            if ((ppi->control & I8255_CTRL_B) == I8255_CTRL_B_OUTPUT) {
+                data = ppi->pb.outp;
+            }
+            else {
+                data = I8255_GET_PB(pins);
+            }
+            break;
+        case 2: /* read from port C */
+            data = I8255_GET_PC(pins);
+            if ((ppi->control & I8255_CTRL_CHI) == I8255_CTRL_CHI_OUTPUT) {
+                data = (data & 0x0F) | (ppi->pc.outp & 0xF0);
+            }
+            if ((ppi->control & I8255_CTRL_CLO) == I8255_CTRL_CLO_OUTPUT) {
+                data = (data & 0xF0) | (ppi->pc.outp & 0x0F);
+            }
+            break;
+        case 3: /* read control word */
+            data = ppi->control;
+            break;
+    }
+    I8255_SET_DATA(pins, data);
+    return pins;
+}
+
+static uint64_t _i8255_write_port_pins(i8255_t* ppi, uint64_t pins) {
+    if ((ppi->control & I8255_CTRL_A_OUTPUT) == I8255_CTRL_A_OUTPUT) {
+        I8255_SET_PA(pins, ppi->pa.outp);
+    }
+    if ((ppi->control & I8255_CTRL_B_OUTPUT) == I8255_CTRL_B_OUTPUT) {
+        I8255_SET_PB(pins, ppi->pb.outp);
+    }
+    if ((ppi->control & I8255_CTRL_CHI) == I8255_CTRL_CHI_OUTPUT) {
+        I8255_SET_PCHI(pins, ppi->pc.outp);
+    }
+    if ((ppi->control & I8255_CTRL_CLO) == I8255_CTRL_CLO_OUTPUT) {
+        I8255_SET_PCLO(pins, ppi->pc.outp);
     }
     return pins;
 }
 
-/* read a value from the PPI */
-static uint8_t _i8255_read(i8255_t* ppi, uint64_t pins) {
-    uint8_t data = 0xFF;
-    switch (pins & (I8255_A0|I8255_A1)) {
-        case 0: /* read from port A */
-            data = _i8255_in_a(ppi);
-            break;
-        case I8255_A0: /* read from port B */
-            data = _i8255_in_b(ppi);
-            break;
-        case I8255_A1: /* read from port C */
-            data = _i8255_in_c(ppi);
-            break;
-        case (I8255_A0|I8255_A1): /* read control word */
-            data = ppi->control;
-            break;
-    }
-    return data;
-}
-
-uint64_t i8255_iorq(i8255_t* ppi, uint64_t pins) {
+uint64_t i8255_tick(i8255_t* ppi, uint64_t pins) {
     CHIPS_ASSERT(ppi);
     if (pins & I8255_CS) {
         if (pins & I8255_RD) {
-            /* read from PPI */
-            const uint8_t data = _i8255_read(ppi, pins);
-            I8255_SET_DATA(pins, data);
+            pins = _i8255_read(ppi, pins);
         }
         else if (pins & I8255_WR) {
-            /* write to PPI */
-            const uint8_t data = I8255_GET_DATA(pins);
-            pins = _i8255_write(ppi, pins, data);
+            _i8255_write(ppi, pins);
         }
-        ppi->pins = (pins & ~I8255_PORT_BITS) |
-                    (ppi->port[I8255_PORT_A] * I8255_PA0) |
-                    (ppi->port[I8255_PORT_B] * I8255_PB0) |
-                    (ppi->port[I8255_PORT_C] * I8255_PC0);
     }
+    pins = _i8255_write_port_pins(ppi, pins);
+    ppi->pins = pins;
     return pins;
 }
 

--- a/chips/i8255.h
+++ b/chips/i8255.h
@@ -229,11 +229,11 @@ typedef struct {
 #define I8255_GET_PB(p) ((uint8_t)(p>>56))
 #define I8255_GET_PC(p) ((uint8_t)(p>>8))
 /* set port pins into pin mask */
-#define I8255_SET_PA(p,a) {p=(p&0xFF00FFFFFFFFFFFF)|((a&0xFFUL)<<48);}
-#define I8255_SET_PB(p,b) {p=(p&0x00FFFFFFFFFFFFFF)|((b&0xFFUL)<<56);}
-#define I8255_SET_PC(p,c) {p=(p&0xFFFFFFFFFFFF00FF)|((c&0xFFUL)<<8);}
-#define I8255_SET_PCHI(p,c) {p=(p&0xFFFFFFFFFFFF0FFF)|((c&0xF0UL)<<8);}
-#define I8255_SET_PCLO(p,c) {p=(p&0xFFFFFFFFFFFFF0FF)|((c&0x0FUL)<<8);}
+#define I8255_SET_PA(p,a) {p=(p&0xFF00FFFFFFFFFFFFULL)|((a&0xFFULL)<<48);}
+#define I8255_SET_PB(p,b) {p=(p&0x00FFFFFFFFFFFFFFULL)|((b&0xFFULL)<<56);}
+#define I8255_SET_PC(p,c) {p=(p&0xFFFFFFFFFFFF00FFULL)|((c&0xFFULL)<<8);}
+#define I8255_SET_PCHI(p,c) {p=(p&0xFFFFFFFFFFFF0FFFULL)|((c&0xF0ULL)<<8);}
+#define I8255_SET_PCLO(p,c) {p=(p&0xFFFFFFFFFFFFF0FFULL)|((c&0x0FULL)<<8);}
 
 /* initialize a new i8255_t instance */
 void i8255_init(i8255_t* ppi);

--- a/chips/m6561.h
+++ b/chips/m6561.h
@@ -21,6 +21,11 @@
 
     TODO: Documentation
 
+    ## Links
+
+    http://sleepingelephant.com/ipw-web/bulletin/bb/viewtopic.php?f=11&t=8733&sid=59d3d281086e98689f6d1f95c4a1c4a9
+
+
     ## zlib/libpng license
 
     Copyright (c) 2019 Andre Weissflog

--- a/systems/atom.h
+++ b/systems/atom.h
@@ -35,7 +35,6 @@
 
     ## TODO
 
-    - VIA emulation is currently only minimal
     - handle shift key (some games use this as jump button)
     - AtomMMC is very incomplete (only what's needed for joystick)
 
@@ -236,7 +235,6 @@ void atom_init(atom_t* sys, const atom_desc_t* desc) {
     mc6847_init(&sys->vdg, &vdg_desc);
 
     i8255_init(&sys->ppi);
-
     m6522_init(&sys->via);
 
     const int audio_hz = _ATOM_DEFAULT(desc->audio_sample_rate, 44100);

--- a/systems/atom.h
+++ b/systems/atom.h
@@ -123,8 +123,6 @@ typedef struct {
     int counter_2_4khz;
     int period_2_4khz;
     bool state_2_4khz;
-    bool out_cass0;
-    bool out_cass1;
     atom_joystick_type_t joystick_type;
     uint8_t kbd_joymask;        /* joystick mask from keyboard-joystick-emulation */
     uint8_t joy_joymask;        /* joystick mask from calls to atom_joystick() */
@@ -196,8 +194,6 @@ void atom_remove_tape(atom_t* sys);
 
 static uint64_t _atom_tick(atom_t* sys, uint64_t pins);
 static uint64_t _atom_vdg_fetch(uint64_t pins, void* user_data);
-static uint8_t _atom_ppi_in(int port_id, void* user_data);
-static uint64_t _atom_ppi_out(int port_id, uint64_t pins, uint8_t data, void* user_data);
 static void _atom_init_keymap(atom_t* sys);
 static void _atom_init_memorymap(atom_t* sys);
 static uint64_t _atom_osload(atom_t* sys, uint64_t pins);
@@ -239,12 +235,7 @@ void atom_init(atom_t* sys, const atom_desc_t* desc) {
     vdg_desc.user_data = sys;
     mc6847_init(&sys->vdg, &vdg_desc);
 
-    i8255_desc_t ppi_desc;
-    _ATOM_CLEAR(ppi_desc);
-    ppi_desc.in_cb = _atom_ppi_in;
-    ppi_desc.out_cb = _atom_ppi_out;
-    ppi_desc.user_data = sys;
-    i8255_init(&sys->ppi, &ppi_desc);
+    i8255_init(&sys->ppi);
 
     m6522_init(&sys->via);
 
@@ -292,8 +283,6 @@ void atom_reset(atom_t* sys) {
     mc6847_reset(&sys->vdg);
     beeper_reset(&sys->beeper);
     sys->state_2_4khz = false;
-    sys->out_cass0 = false;
-    sys->out_cass1 = false;
 }
 
 void atom_tick(atom_t* sys) {
@@ -393,17 +382,12 @@ uint64_t _atom_tick(atom_t* sys, uint64_t pins) {
     /* address decoding */
     const uint16_t addr = M6502_GET_ADDR(pins);
     uint64_t via_pins = pins & M6502_PIN_MASK;
+    uint64_t ppi_pins = (pins & M6502_PIN_MASK) & ~(I8255_RD|I8255_WR|I8255_PA_PINS);
     if ((addr >= 0xB000) && (addr < 0xC000)) {
         /* memory-mapped IO area */
         if ((addr >= 0xB000) && (addr < 0xB400)) {
-            /* i8255 PPI: http://www.acornatom.nl/sites/fpga/www.howell1964.freeserve.co.uk/acorn/atom/amb/amb_8255.htm */
-            uint64_t ppi_pins = (pins & M6502_PIN_MASK) | I8255_CS;
-            if (pins & M6502_RW) { ppi_pins |= I8255_RD; }  /* PPI read access */
-            else { ppi_pins |= I8255_WR; }                  /* PPI write access */
-            if (pins & M6502_A0) { ppi_pins |= I8255_A0; }  /* PPI has 4 addresses (port A,B,C or control word */
-            if (pins & M6502_A1) { ppi_pins |= I8255_A1; }
-            pins = i8255_iorq(&sys->ppi, ppi_pins) & M6502_PIN_MASK;
-        }       
+            ppi_pins |= I8255_CS;
+        }
         else if ((addr >= 0xB400) && (addr < 0xB800)) {
             /* extensions (only rudimentary)
                 FIXME: implement a proper AtoMMC emulation, for now just
@@ -453,12 +437,61 @@ uint64_t _atom_tick(atom_t* sys, uint64_t pins) {
         }
     }
 
-    /* tick the VIA */
-    via_pins = m6522_tick(&sys->via, via_pins);
-    if ((via_pins & (M6522_RW|M6522_CS1)) == (M6522_RW|M6522_CS1)) {
-        pins = M6502_COPY_DATA(pins, via_pins);
+    /* tick the PPI
+        http://www.acornatom.nl/sites/fpga/www.howell1964.freeserve.co.uk/acorn/atom/amb/amb_8255.htm
+
+        Port inputs:
+            PB0..PB7:   keyboard matrix rows
+            PC4:        2400 Hz tick
+            PC5:        cassette input (FIXME: not emulated)
+            PC6:        keyboard repeat (FIXME: not emulated)
+            PC7:        MC6847 FSYNC
+
+        Port output:
+            PA0..PA3:   keyboard matrix column nr.
+            PA4..PA7:   MC6847 graphics mode (4: A/G, 5..7: GM0..2)
+            PC0:        cassette output (FIXME: not emulated)
+            PC1:        enable 2.4kHz to cassette output
+            PC2:        beeper
+            PC3:        MC6847 CSS
+
+        The port C output lines, bits O to 3, may be used for user
+        applications when the cassette interface is not being used.
+    */
+    {
+        ppi_pins |= (pins & M6502_RW) ? I8255_RD : I8255_WR;
+        I8255_SET_PB(ppi_pins, ~kbd_scan_lines(&sys->kbd));
+        if (sys->state_2_4khz) {
+            ppi_pins |= I8255_PC4;
+        }
+        ppi_pins |= I8255_PC6;
+        if (0 == (sys->vdg.pins & MC6847_FS)) {
+            ppi_pins |= I8255_PC7;
+        }
+        ppi_pins = i8255_tick(&sys->ppi, ppi_pins);
+        kbd_set_active_columns(&sys->kbd, 1<<(I8255_GET_PA(ppi_pins) & 0x0F));
+        /* FIXME FIXME FIXME: remove mc6847_ctrl() */
+        uint64_t vdg_pins = 0;
+        uint64_t vdg_mask = MC6847_AG|MC6847_GM0|MC6847_GM1|MC6847_GM2|MC6847_CSS;
+        if (ppi_pins & I8255_PA4) { vdg_pins |= MC6847_AG; }
+        if (ppi_pins & I8255_PA5) { vdg_pins |= MC6847_GM0; }
+        if (ppi_pins & I8255_PA6) { vdg_pins |= MC6847_GM1; }
+        if (ppi_pins & I8255_PA7) { vdg_pins |= MC6847_GM2; }
+        beeper_set(&sys->beeper, 0 == (ppi_pins & I8255_PC2));
+        if (ppi_pins & I8255_PC3) {
+            vdg_pins |= MC6847_CSS;
+        }
+        mc6847_ctrl(&sys->vdg, vdg_pins, vdg_mask);
     }
-    pins = (pins & ~M6502_IRQ) | (via_pins & M6502_IRQ);
+
+    /* tick the VIA */
+    {
+        via_pins = m6522_tick(&sys->via, via_pins);
+        if ((via_pins & (M6522_RW|M6522_CS1)) == (M6522_RW|M6522_CS1)) {
+            pins = M6502_COPY_DATA(pins, via_pins);
+        }
+        pins = (pins & ~M6502_IRQ) | (via_pins & M6502_IRQ);
+    }
 
     /* check if the trapped OSLoad function was hit to implement tape file loading
         http://ladybug.xs4all.nl/arlet/fpga/6502/kernel.dis
@@ -490,103 +523,6 @@ uint64_t _atom_vdg_fetch(uint64_t pins, void* user_data) {
     if (data & (1<<6)) { pins |= (MC6847_AS|MC6847_INTEXT); }
     else               { pins &= ~(MC6847_AS|MC6847_INTEXT); }
     return pins;
-}
-
-uint64_t _atom_ppi_out(int port_id, uint64_t pins, uint8_t data, void* user_data) {
-    atom_t* sys = (atom_t*) user_data;
-    /*
-        FROM Atom Theory and Praxis (and MAME)
-        The  8255  Programmable  Peripheral  Interface  Adapter  contains  three
-        8-bit ports, and all but one of these lines is used by the ATOM.
-        Port A - #B000
-               Output bits:      Function:
-                    O -- 3     Keyboard column
-                    4 -- 7     Graphics mode (4: A/G, 5..7: GM0..2)
-        Port B - #B001
-               Input bits:       Function:
-                    O -- 5     Keyboard row
-                      6        CTRL key (low when pressed)
-                      7        SHIFT keys {low when pressed)
-        Port C - #B002
-               Output bits:      Function:
-                    O          Tape output
-                    1          Enable 2.4 kHz to cassette output
-                    2          Loudspeaker
-                    3          Not used (??? see below)
-               Input bits:       Function:
-                    4          2.4 kHz input
-                    5          Cassette input
-                    6          REPT key (low when pressed)
-                    7          60 Hz sync signal (low during flyback)
-        The port C output lines, bits O to 3, may be used for user
-        applications when the cassette interface is not being used.
-    */
-    if (I8255_PORT_A == port_id) {
-        /* PPI port A
-            0..3:   keyboard matrix column to scan next
-            4:      MC6847 A/G
-            5:      MC6847 GM0
-            6:      MC6847 GM1
-            7:      MC6847 GM2
-        */
-        kbd_set_active_columns(&sys->kbd, 1<<(data & 0x0F));
-        uint64_t vdg_pins = 0;
-        uint64_t vdg_mask = MC6847_AG|MC6847_GM0|MC6847_GM1|MC6847_GM2;
-        if (data & (1<<4)) { vdg_pins |= MC6847_AG; }
-        if (data & (1<<5)) { vdg_pins |= MC6847_GM0; }
-        if (data & (1<<6)) { vdg_pins |= MC6847_GM1; }
-        if (data & (1<<7)) { vdg_pins |= MC6847_GM2; }
-        mc6847_ctrl(&sys->vdg, vdg_pins, vdg_mask);
-    }
-    else if (I8255_PORT_C == port_id) {
-        /* PPI port C output:
-            0:  output: cass 0
-            1:  output: cass 1
-            2:  output: speaker
-            3:  output: MC6847 CSS
-
-            NOTE: only the MC6847 CSS pin is emulated here
-        */
-        sys->out_cass0 = 0 == (data & (1<<0));
-        sys->out_cass1 = 0 == (data & (1<<1));
-        beeper_set(&sys->beeper, 0 == (data & (1<<2)));
-        uint64_t vdg_pins = 0;
-        uint64_t vdg_mask = MC6847_CSS;
-        if (data & (1<<3)) {
-            vdg_pins |= MC6847_CSS;
-        }
-        mc6847_ctrl(&sys->vdg, vdg_pins, vdg_mask);
-    }
-    return pins;
-}
-
-uint8_t _atom_ppi_in(int port_id, void* user_data) {
-    atom_t* sys = (atom_t*) user_data;
-    uint8_t data = 0;
-    if (I8255_PORT_B == port_id) {
-        /* keyboard row state */
-        data = ~kbd_scan_lines(&sys->kbd);
-    }
-    else if (I8255_PORT_C == port_id) {
-        /*  PPI port C input:
-            4:  input: 2400 Hz
-            5:  input: cassette
-            6:  input: keyboard repeat
-            7:  input: MC6847 FSYNC
-
-            NOTE: only the 2400 Hz oscillator and FSYNC pins is emulated here
-        */
-        if (sys->state_2_4khz) {
-            data |= (1<<4);
-        }
-        /* FIXME: always send REPEAT key as 'not pressed' */
-        data |= (1<<6);
-        /* vblank pin (cleared during vblank) */
-        if (0 == (sys->vdg.pins & MC6847_FS)) {
-            data |= (1<<7);
-        }
-    }
-    return data;
 }
 
 static void _atom_init_keymap(atom_t* sys) {

--- a/ui/ui_i8255.h
+++ b/ui/ui_i8255.h
@@ -142,15 +142,10 @@ static void _ui_i8255_draw_state(ui_i8255_t* win) {
     ImGui::Text("%s", ((ppi->control & I8255_CTRL_CHI) == I8255_CTRL_CHI_INPUT) ? "IN":"OUT"); ImGui::NextColumn();
     ImGui::Text("%s", ((ppi->control & I8255_CTRL_CLO) == I8255_CTRL_CLO_INPUT) ? "IN":"OUT"); ImGui::NextColumn();
     ImGui::Text("Output"); ImGui::NextColumn();
-    ImGui::Text("%02X", ppi->output[I8255_PORT_A]); ImGui::NextColumn();
-    ImGui::Text("%02X", ppi->output[I8255_PORT_B]); ImGui::NextColumn();
-    ImGui::Text("%X", ppi->output[I8255_PORT_C] >> 4); ImGui::NextColumn();
-    ImGui::Text("%X", ppi->output[I8255_PORT_C] & 0xF); ImGui::NextColumn();
-    ImGui::Text("Port"); ImGui::NextColumn();
-    ImGui::Text("%02X", ppi->port[I8255_PORT_A]); ImGui::NextColumn();
-    ImGui::Text("%02X", ppi->port[I8255_PORT_B]); ImGui::NextColumn();
-    ImGui::Text("%X", ppi->port[I8255_PORT_C] >> 4); ImGui::NextColumn();
-    ImGui::Text("%X", ppi->port[I8255_PORT_C] & 0xF); ImGui::NextColumn();
+    ImGui::Text("%02X", ppi->pa.outp); ImGui::NextColumn();
+    ImGui::Text("%02X", ppi->pb.outp); ImGui::NextColumn();
+    ImGui::Text("%X", ppi->pc.outp >> 4); ImGui::NextColumn();
+    ImGui::Text("%X", ppi->pc.outp & 0xF); ImGui::NextColumn();
     ImGui::Columns(); ImGui::Separator();
     ImGui::Text("Control: %02X", ppi->control);
 }


### PR DESCRIPTION
...plus the required changes in atom.h and cpc.h (atom.h is complete, cpc.h is only hacked so far to work with new i8255 API).