### PR TITLE
[vic20] fix wrong keys, add code for missing keys

### DIFF
--- a/systems/vic20.h
+++ b/systems/vic20.h
@@ -596,15 +596,15 @@ static void _vic20_init_key_map(vic20_t* sys) {
         "7YGVBHU8"  // row 3
         "9IJNMKO0"  // row 4
         "+PL,.:@-"  // row 5
-        "~*;/ =  "  // row 6, ~ is british pound
+        "~*;/ =^ "  // row 6, ~ is british pound
         "        "  // row 7
 
         /* shift */
         "!     q\""
         "#wa zse$"
-        "%rdxcft^"
-        "&ygvbhu*"
-        "(ijnmko)"
+        "%rdxcft&"
+        "'ygvbhu("
+        ")ijnmko "
         " pl<>[  "
         "$ ]?    "
         "        ";
@@ -633,6 +633,11 @@ static void _vic20_init_key_map(vic20_t* sys) {
     kbd_register_key(&sys->kbd, 0x01, 0, 7, 0);    /* delete */
     kbd_register_key(&sys->kbd, 0x0D, 1, 7, 0);    /* return */
     kbd_register_key(&sys->kbd, 0x03, 3, 0, 0);    /* stop */
+    kbd_register_key(&sys->kbd, 0x04, 1, 0, 0);    /* left arrow */
+    kbd_register_key(&sys->kbd, 0x05, 7, 6, 0);    /* home */
+    kbd_register_key(&sys->kbd, 0x06, 7, 6, 1);    /* clr */
+    kbd_register_key(&sys->kbd, 0x0E, 2, 0, 0);    /* ctrl */
+    kbd_register_key(&sys->kbd, 0x0F, 5, 0, 0);    /* C= key */
     kbd_register_key(&sys->kbd, 0xF1, 4, 7, 0);
     kbd_register_key(&sys->kbd, 0xF2, 4, 7, 1);
     kbd_register_key(&sys->kbd, 0xF3, 5, 7, 0);

--- a/systems/vic20.h
+++ b/systems/vic20.h
@@ -630,7 +630,8 @@ static void _vic20_init_key_map(vic20_t* sys) {
     kbd_register_key(&sys->kbd, 0x09, 2, 7, 0);    /* cursor right */
     kbd_register_key(&sys->kbd, 0x0A, 3, 7, 0);    /* cursor down */
     kbd_register_key(&sys->kbd, 0x0B, 3, 7, 1);    /* cursor up */
-    kbd_register_key(&sys->kbd, 0x01, 0, 7, 0);    /* delete */
+    kbd_register_key(&sys->kbd, 0x07, 0, 7, 1);    /* inst */
+    kbd_register_key(&sys->kbd, 0x01, 0, 7, 0);    /* del */
     kbd_register_key(&sys->kbd, 0x0D, 1, 7, 0);    /* return */
     kbd_register_key(&sys->kbd, 0x03, 3, 0, 0);    /* stop */
     kbd_register_key(&sys->kbd, 0x04, 1, 0, 0);    /* left arrow */


### PR DESCRIPTION
This PR fixes the following keys:
- `&` currently produces `'`
- `(` currently produces `)`
- `)` currently produces `0`
- `^` currently produces `&` 
- `*` currently produces `)` 

It also adds key codes for `HOME`, `CLR`, `INST`, `DEL`, `CTRL` and `C=` so that they can be referenced from the host.