### PR TITLE
[z80.h] do not clear Z80_INT pin

### DIFF
--- a/chips/z80.h
+++ b/chips/z80.h
@@ -1391,11 +1391,9 @@ uint32_t z80_exec(z80_t* cpu, uint32_t num_ticks) {
             int trap_id = trap(pc,ticks,pins,cpu->trap_user_data);
             if (trap_id) {
                 cpu->trap_id=trap_id;
-                pins &= ~Z80_INT;
                 break;
             }
         }
-        pins &= ~Z80_INT;
         pre_pins = pins;
     } while (ticks < num_ticks);
     /* flush local state back to persistent CPU state before leaving */


### PR DESCRIPTION
If my understanding of the code is correct, the `Z80_INT` is an input pin and so it should not be modified by the Z80. 

This PR removes the two statements where the pin was cleared. Note that the similar `Z80_NMI` pin is currently not cleared, so with this change the two pins behave the same way.