### PR TITLE
[mc6847] improvements

### DIFF
--- a/chips/mc6847.h
+++ b/chips/mc6847.h
@@ -223,6 +223,9 @@ typedef struct {
     uint32_t alnum_orange;
     uint32_t alnum_dark_orange;
 
+    /* border color, picked only at end of active area */
+    uint32_t border_color;
+
     /* internal counters */
     int h_count;
     int h_sync_start;
@@ -420,20 +423,20 @@ static inline uint32_t _mc6847_border_color(mc6847_t* vdg, uint64_t pins) {
 
 static void _mc6847_decode_border(mc6847_t* vdg, uint64_t pins, int y) {
     uint32_t* dst = &(vdg->rgba8_buffer[y * MC6847_DISPLAY_WIDTH]);
-    uint32_t c = _mc6847_border_color(vdg, pins);
     for (int x = 0; x < MC6847_DISPLAY_WIDTH; x++) {
-        *dst++ = c;
+        *dst++ = vdg->border_color;
     }
 }
 
 static uint64_t _mc6847_decode_scanline(mc6847_t* vdg, uint64_t pins, int y) {
     uint32_t* dst = &(vdg->rgba8_buffer[(y+MC6847_TOP_BORDER_LINES) * MC6847_DISPLAY_WIDTH]);
-    uint32_t bc = _mc6847_border_color(vdg, pins);
+    vdg->border_color = _mc6847_border_color(vdg, pins);
+
     void* ud = vdg->user_data;
 
     /* left border */
     for (int i = 0; i < MC6847_BORDER_PIXELS; i++) {
-        *dst++ = bc;
+        *dst++ = vdg->border_color;
     }
 
     /* visible scanline */
@@ -568,7 +571,7 @@ static uint64_t _mc6847_decode_scanline(mc6847_t* vdg, uint64_t pins, int y) {
 
     /* right border */
     for (int i = 0; i < MC6847_BORDER_PIXELS; i++) {
-        *dst++ = bc;
+        *dst++ = vdg->border_color;
     }
 
     return pins;

--- a/chips/mc6847.h
+++ b/chips/mc6847.h
@@ -232,6 +232,7 @@ typedef struct {
     int h_sync_end;
     int h_period;
     int l_count;
+    int h_fetchpos;
 
     /* true during field-sync */
     bool fs;
@@ -458,6 +459,7 @@ static uint64_t _mc6847_decode_scanline(mc6847_t* vdg, uint64_t pins, int y) {
             uint32_t fg_color = (pins & MC6847_CSS) ? vdg->palette[4] : vdg->palette[0];
             for (int x = 0; x < bytes_per_row; x++) {
                 MC6847_SET_ADDR(pins, addr++);
+                vdg->h_fetchpos = x;
                 pins = vdg->fetch_cb(pins, ud);
                 uint8_t m = MC6847_GET_DATA(pins);
                 for (int p = 7; p >= 0; p--) {
@@ -484,6 +486,7 @@ static uint64_t _mc6847_decode_scanline(mc6847_t* vdg, uint64_t pins, int y) {
             uint16_t addr = (y / row_height) * bytes_per_row;
             for (int x = 0; x < bytes_per_row; x++) {
                 MC6847_SET_ADDR(pins, addr++);
+                vdg->h_fetchpos = x;
                 pins = vdg->fetch_cb(pins, ud);
                 uint8_t m = MC6847_GET_DATA(pins);
                 for (int p = 6; p >= 0; p -= 2) {
@@ -509,6 +512,7 @@ static uint64_t _mc6847_decode_scanline(mc6847_t* vdg, uint64_t pins, int y) {
         uint32_t alnum_bg = (pins & MC6847_CSS) ? vdg->alnum_dark_orange : vdg->alnum_dark_green;
         for (int x = 0; x < 32; x++) {
             MC6847_SET_ADDR(pins, addr++);
+            vdg->h_fetchpos = x;
             pins = vdg->fetch_cb(pins, ud);
             uint8_t chr = MC6847_GET_DATA(pins);
             if (pins & MC6847_AS) {

--- a/chips/mc6847.h
+++ b/chips/mc6847.h
@@ -204,6 +204,7 @@ typedef struct {
     /* size of rgba8_buffer in bytes (must be at least 320*244*4=312320 bytes) */
     uint32_t rgba8_buffer_size;
     /* memory-fetch callback */
+    uint32_t *palette;
     mc6847_fetch_t fetch_cb;
     /* optional user-data for the fetch callback */
     void* user_data;
@@ -316,21 +317,33 @@ void mc6847_init(mc6847_t* vdg, const mc6847_desc_t* desc) {
 
         color intensities are slightly boosted
     */
-    vdg->palette[0] = _MC6847_RGBA(19, 146, 11);      /* green */
-    vdg->palette[1] = _MC6847_RGBA(155, 150, 10);     /* yellow */
-    vdg->palette[2] = _MC6847_RGBA(2, 22, 175);       /* blue */
-    vdg->palette[3] = _MC6847_RGBA(155, 22, 7);       /* red */
-    vdg->palette[4] = _MC6847_RGBA(141, 150, 154);    /* buff */
-    vdg->palette[5] = _MC6847_RGBA(15, 143, 155);     /* cyan */
-    vdg->palette[6] = _MC6847_RGBA(139, 39, 155);     /* cyan */
-    vdg->palette[7] = _MC6847_RGBA(140, 31, 11);      /* orange */
+    if(desc->palette == NULL) {
+      vdg->palette[0] = _MC6847_RGBA(19, 146, 11);      /* green */
+      vdg->palette[1] = _MC6847_RGBA(155, 150, 10);     /* yellow */
+      vdg->palette[2] = _MC6847_RGBA(2, 22, 175);       /* blue */
+      vdg->palette[3] = _MC6847_RGBA(155, 22, 7);       /* red */
+      vdg->palette[4] = _MC6847_RGBA(141, 150, 154);    /* buff */
+      vdg->palette[5] = _MC6847_RGBA(15, 143, 155);     /* cyan */
+      vdg->palette[6] = _MC6847_RGBA(139, 39, 155);     /* cyan */
+      vdg->palette[7] = _MC6847_RGBA(140, 31, 11);      /* orange */
 
-    /* black level color, and alpha-numeric display mode colors */
-    vdg->black = 0xFF111111;
-    vdg->alnum_green = _MC6847_RGBA(19, 146, 11);
-    vdg->alnum_dark_green = 0xFF002400;
-    vdg->alnum_orange = _MC6847_RGBA(140, 31, 11);
-    vdg->alnum_dark_orange = 0xFF000E22;
+      /* black level color, and alpha-numeric display mode colors */
+      vdg->black = 0xFF111111;
+      vdg->alnum_green = _MC6847_RGBA(19, 146, 11);
+      vdg->alnum_dark_green = 0xFF002400;
+      vdg->alnum_orange = _MC6847_RGBA(140, 31, 11);
+      vdg->alnum_dark_orange = 0xFF000E22;
+    } else {
+      /* custom palette */ 
+      for(int i=0; i<8; i++) { 
+         vdg->palette[i] = desc->palette[i];
+      }
+      vdg->black = desc->palette[8];
+      vdg->alnum_green = desc->palette[9];
+      vdg->alnum_dark_green = desc->palette[10];
+      vdg->alnum_orange = desc->palette[11];
+      vdg->alnum_dark_orange = desc->palette[12];
+    }  
 }
 
 void mc6847_reset(mc6847_t* vdg) {


### PR DESCRIPTION
This PR implements some improvements on the MC6847 video chip:

- The border color now changes only during the scanlines of the active area, before it was on every scanline (I checked it on a real hardware)
- There is now an optional custom palette. The system I am emulating has a switch that turns off color making it a BW display. So by feeding a monochrome palette you can emulate that too. Or you can use your own palette if you think the default palette doesn't match the original hardware (too saturated etc).
- When fetching from video ram, the chip updates the internal variable `fetchpos` with the actual position on the horizontal line. Knowing the horizontal position is useful in my system to emulate the glitch that occurs when there is memory contention between CPU and VDG (the result is something we call "snow" effect).
- variable tick speed: before the MC6847 was ticked at the fixed speed of 3.579 MHz; but in the system I use it is clocked at the same rate of the CPU (3.54 MHz). So it is now be possible to change it.

I also have another improvement that I did not commit because I haven't seen it in any other of you video chips. It's the ability to callback a function at the end of the video frame for updating the video. If find it very convenient to update the screen by that method. Tell me if you like the idea.

By the way, I'm using your MC6847 (and your Z80 as well) to emulate a Video Technology Laser 310 computer (aka Dick Smith VZ300). You can run it online [here](https://nippur72.github.io/laser310-emu). It's the 4th system that I emulate with your "chips" :smile: 

(P.S. I know you're busy with other projects so I don't expect you to review this PR anytime soon, that's ok.)


