### PR TITLE
z80: Fix Z80 IO port write example code

### DIFF
--- a/chips/z80.h
+++ b/chips/z80.h
@@ -126,7 +126,7 @@
                     // handle IO input request at port
                     ...
                 }
-                else if (pins & Z80_RD) {
+                else if (pins & Z80_WR) {
                     // handle IO output request at port
                     ...
                 }
@@ -163,7 +163,7 @@
                     // handle IO input request at port `addr`
                     ...
                 }
-                else if (pins & Z80_RD) {
+                else if (pins & Z80_WR) {
                     // handle IO output request at port `addr`
                     ...
                 }

--- a/codegen/z80.template.h
+++ b/codegen/z80.template.h
@@ -126,7 +126,7 @@
                     // handle IO input request at port
                     ...
                 }
-                else if (pins & Z80_RD) {
+                else if (pins & Z80_WR) {
                     // handle IO output request at port
                     ...
                 }
@@ -163,7 +163,7 @@
                     // handle IO input request at port `addr`
                     ...
                 }
-                else if (pins & Z80_RD) {
+                else if (pins & Z80_WR) {
                     // handle IO output request at port `addr`
                     ...
                 }


### PR DESCRIPTION
This fixes the example code in the comments for the new cycle-stepped Z80.

Great work by the way.