### PR TITLE
fix overflowing video ram address

### DIFF
--- a/systems/vic20.h
+++ b/systems/vic20.h
@@ -564,7 +564,7 @@ uint32_t vic20_exec(vic20_t* sys, uint32_t micro_seconds) {
 
 static uint16_t _vic20_vic_fetch(uint16_t addr, void* user_data) {
     vic20_t* sys = (vic20_t*) user_data;
-    uint16_t data = (sys->color_ram[addr & 0x03FF]<<8) | mem_rd(&sys->mem_vic, addr);
+    uint16_t data = (sys->color_ram[addr & 0x03FF]<<8) | mem_rd(&sys->mem_vic, addr & 0x3FFF);
     return data;
 }
 


### PR DESCRIPTION
this PR fixes a small bug on the VIC-20 that causes no display of characters from 128 to 255 when the VIC video chip is set to display definable characters from RAM at $1E00 (e.g. `POKE 36869,255`). 

In a such situation, a real VIC20 reads characters from 128 to 255 from ROM at $8000; current emulation on the contrary fetches from memory address at $4000. 