### PR TITLE
Sample at every tick

### DIFF
--- a/chips/beeper.h
+++ b/chips/beeper.h
@@ -116,11 +116,12 @@ static float _beeper_dcadjust(beeper_t* bp, float s) {
 }
 
 bool beeper_tick(beeper_t* bp) {
+    _beeper_dcadjust(bp, (float)bp->state * bp->volume * bp->base_volume);
     /* generate a new sample? */
     bp->counter -= BEEPER_FIXEDPOINT_SCALE;
     if (bp->counter <= 0) {
         bp->counter += bp->period;
-        bp->sample = _beeper_dcadjust(bp, (float)bp->state) * bp->volume * bp->base_volume;
+        bp->sample = bp->dcadj_sum / BEEPER_DCADJ_BUFLEN;
         return true;
     }
     return false;

--- a/chips/beeper.h
+++ b/chips/beeper.h
@@ -107,12 +107,11 @@ void beeper_reset(beeper_t* b) {
    from the chip simulation which is >0.0 gets converted to
    a +/- sample value)
 */
-static float _beeper_dcadjust(beeper_t* bp, float s) {
+static void _beeper_dcadjust(beeper_t* bp, float s) {
     bp->dcadj_sum -= bp->dcadj_buf[bp->dcadj_pos];
     bp->dcadj_sum += s;
     bp->dcadj_buf[bp->dcadj_pos] = s;
     bp->dcadj_pos = (bp->dcadj_pos + 1) & (BEEPER_DCADJ_BUFLEN-1);
-    return s - (bp->dcadj_sum / BEEPER_DCADJ_BUFLEN);
 }
 
 bool beeper_tick(beeper_t* bp) {

--- a/chips/beeper.h
+++ b/chips/beeper.h
@@ -20,7 +20,7 @@
         2. Altered source versions must be plainly marked as such, and must not
         be misrepresented as being the original software.
         3. This notice may not be removed or altered from any source
-        distribution. 
+        distribution.
 */
 #include <stdint.h>
 #include <stdbool.h>
@@ -32,7 +32,7 @@ extern "C" {
 // error-accumulation precision boost
 #define BEEPER_FIXEDPOINT_SCALE (16)
 // DC adjust buffer size
-#define BEEPER_DCADJ_BUFLEN (512)
+#define BEEPER_DCADJ_BUFLEN (128)
 
 // initialization parameters
 typedef struct {


### PR DESCRIPTION
The beeper misses some input values because the input state is only ever used when needed to produce an output sample. Sound quality suffers, I noticed it when comparing the Nonamed intro music with Fuse.

This PR takes every beeper tick into account, using the average when an output sample is required. Nonamed now sounds extremely similar to Fuse when configured to not use audio filters.

I've decreased the buffer because 512 made it sound a bit muffled. Both the sampling scheme and the buffer size were suggested by MartianGirl, who has all the merit.

I'm not sure if the change applies to systems other than the ZX Spectrum, I'm not familiar with them.

I'm also not sure if the comment below applies anymore, so I left it in the source code:

```c
/* DC adjustment filter from StSound, this moves an "offcenter"
   signal back to the zero-line (e.g. the volume-level output
   from the chip simulation which is >0.0 gets converted to
   a +/- sample value)
*/
```

[comparison.zip](https://github.com/user-attachments/files/16099841/comparison.zip)

