### PR TITLE
Allow invalid regs

### DIFF
--- a/chips/ay38910.h
+++ b/chips/ay38910.h
@@ -622,6 +622,9 @@ uint64_t ay38910_iorq(ay38910_t* ay, uint64_t pins) {
             const uint8_t data = ay->reg[ay->addr];
             AY38910_SET_DATA(pins, data);
         }
+        else {
+            AY38910_SET_DATA(pins, 0);
+        }
         AY38910_SET_PA(pins, ay->port_a);
         AY38910_SET_PB(pins, ay->port_b);
         ay->pins = pins;

--- a/chips/ay38910.h
+++ b/chips/ay38910.h
@@ -643,16 +643,18 @@ uint64_t ay38910_tick(ay38910_t* ay, uint64_t pins) {
 */
 
 void ay38910_set_register(ay38910_t* ay, uint8_t addr, uint8_t data) {
-    CHIPS_ASSERT(ay && (addr < AY38910_NUM_REGISTERS));
-    ay->reg[addr] = data & _ay38910_reg_mask[addr];
-    _ay38910_update_values(ay);
-    if (addr == AY38910_REG_ENV_SHAPE_CYCLE) {
-        _ay38910_restart_env_shape(ay);
+    CHIPS_ASSERT(ay);
+    if (addr < AY38910_NUM_REGISTERS) {
+        ay->reg[addr] = data & _ay38910_reg_mask[addr];
+        _ay38910_update_values(ay);
+        if (addr == AY38910_REG_ENV_SHAPE_CYCLE) {
+            _ay38910_restart_env_shape(ay);
+        }
     }
 }
 
 void ay38910_set_addr_latch(ay38910_t* ay, uint8_t addr) {
-    CHIPS_ASSERT(ay && (addr < AY38910_NUM_REGISTERS));
+    CHIPS_ASSERT(ay);
     ay->addr = addr;
 }
 


### PR DESCRIPTION
[This thread](https://worldofspectrum.org/forums/discussion/23327/) at World of Spectrum says that it's valid to write to invalid AY registers, and that you can read back the value, which decays over time.

This PR doesn't implement the decay, but makes it possible to set the register address to an invalid one, and makes reading back from it return 0, as if it instantly decays.

I made this change because there's this SZX snapshot that has the last AY register address set to 16, and it was causing an assert. Instead of making it a special case in my code, I thought it would be nice if it was at least partially implemented in `ay38910.h`.